### PR TITLE
Document the API protection model for the Rust runtime

### DIFF
--- a/deploy/api/deployment.yaml
+++ b/deploy/api/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flink-job-ui
+  annotations:
+    flink-job-ui.io/runtime: rust
+    flink-job-ui.io/auth-owner: upstream-ingress
+    flink-job-ui.io/metrics-policy: protected-or-internal-only
 spec:
   replicas: 1
   selector:
@@ -11,6 +15,9 @@ spec:
     metadata:
       labels:
         app: flink-job-ui
+        app.kubernetes.io/runtime: rust
+      annotations:
+        flink-job-ui.io/auth-owner: upstream-ingress
     spec:
       serviceAccountName: flink-job-ui
       containers:

--- a/deploy/api/ingress.yaml
+++ b/deploy/api/ingress.yaml
@@ -2,11 +2,19 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flink-job-ui
+  annotations:
+    flink-job-ui.io/auth-owner: upstream-ingress
+    flink-job-ui.io/public-surface: ui-and-readonly-api
+    flink-job-ui.io/metrics-policy: do-not-expose-anonymously
+    # Configure your ingress-controller-specific auth integration here
+    # (for example OAuth2 proxy, SSO, or mTLS) before exposing this host.
 spec:
   rules:
     - host: flink-jobs.example.com
       http:
         paths:
+          # This public ingress fronts the UI and readonly API.
+          # Keep /metrics behind the same auth boundary or on a separate internal ingress.
           - path: /
             pathType: Prefix
             backend:

--- a/docs/architecture/flink-job-ui-v1.md
+++ b/docs/architecture/flink-job-ui-v1.md
@@ -45,7 +45,14 @@ Raw status is still preserved in the details view for troubleshooting.
 - `FLINK_UI_CLUSTERS_JSON` supports explicit cluster config
 - `K8S_*` env vars support a single-cluster deployment
 
+## Protection model
+- The supported production runtime is the Rust service in `apps/api-rs`; both `npm start` and the example Kubernetes deployment execute that binary.
+- End-user authentication is currently owned by the upstream ingress or reverse proxy, not by the application process itself.
+- The same upstream auth boundary is expected to cover both the static UI (`/`) and the read-only API (`/api/*`).
+- `/metrics` is an operational endpoint. Keep it behind the same trusted ingress auth layer or expose it only on an internal-only scrape path.
+- Local fixture-mode development is intentionally ungated so a single developer can run the UI without provisioning SSO.
+
 ## Next extension points
 - namespace or cluster-level watches instead of polling
-- auth/SSO in front of the UI
+- app-level auth if the ingress-owned model no longer fits the deployment environment
 - control actions like suspend/cancel after read-only v1 is accepted

--- a/docs/ops/local-dev.md
+++ b/docs/ops/local-dev.md
@@ -7,6 +7,12 @@ npm run dev
 
 Open `http://localhost:3000`.
 
+## Runtime and auth model
+- `npm start` delegates to `npm run start:rust`, which runs the supported Rust backend in `apps/api-rs`.
+- `npm run dev` keeps fixture-mode local development intentionally unauthenticated.
+- Production traffic for `/` and `/api/*` is expected to be authenticated by an upstream ingress or reverse proxy before requests reach the app.
+- `/metrics` is an operations endpoint and should stay behind the same trusted auth boundary or a separate internal-only scrape path.
+
 ## Run tests
 ```bash
 cargo test --manifest-path apps/api-rs/Cargo.toml
@@ -40,6 +46,8 @@ This runs:
 - a fixture-mode container smoke check
 
 ## Run against Kubernetes
+The example deployment assumes the Rust backend is the only supported production runtime and that ingress/reverse-proxy auth is configured in front of the app.
+
 Provide either:
 
 1. `FLINK_UI_CLUSTERS_JSON` with one or more cluster objects, or
@@ -66,3 +74,4 @@ npm start
 - `FlinkSessionJob` collection is best-effort; clusters without that CR kind still work.
 - Flink REST enrichment is optional and never blocks job listing.
 - There is no separate Node backend runtime path anymore.
+- Do not expose `/metrics` anonymously; keep it behind upstream auth or an internal-only operations path.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "cargo run --manifest-path apps/api-rs/Cargo.toml",
-    "dev": "FIXTURE_MODE=true cargo run --manifest-path apps/api-rs/Cargo.toml",
+    "start": "npm run start:rust",
+    "start:rust": "cargo run --manifest-path apps/api-rs/Cargo.toml",
+    "dev": "FIXTURE_MODE=true npm run start:rust",
     "build": "node scripts/build.mjs",
     "ci:smoke": "node scripts/ci-smoke.mjs",
     "test": "node --test tests/web/*.test.js"


### PR DESCRIPTION
## Summary
- document the supported production runtime as the Rust service and make the ingress-owned auth boundary explicit
- clarify local-dev versus production auth expectations, including the `/metrics` exposure policy
- add neutral deployment/ingress annotations so operators see the intended protection contract in repo manifests

## Testing
- npm run ci:smoke

Related: #1

## Summary by Sourcery

Document the Rust backend as the supported production runtime and clarify the ingress-owned authentication and metrics exposure model across docs and manifests.

Enhancements:
- Add neutral runtime and auth ownership annotations to the deployment and ingress manifests to make the expected protection contract explicit to operators.
- Refactor npm scripts so `npm start` and `npm run dev` consistently delegate to a shared Rust backend start command.

Documentation:
- Describe the protection model for the Rust-based API/UI, including ingress-owned auth, UI/API surface expectations, and metrics exposure policy in architecture docs.
- Clarify local development versus production auth behavior, including fixture-mode being unauthenticated and `/metrics` remaining an internal or protected endpoint in local-dev and Kubernetes docs.