### PR TITLE
Add v2 baseline job cancel/suspend/resume actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Example manifests live under:
 - `deploy/api/deployment.yaml`
 - `deploy/api/service.yaml`
 - `deploy/api/ingress.yaml`
+- `deploy/rbac/api-reader.yaml`
 
 The included deployment assumes:
 
@@ -396,6 +397,8 @@ The included deployment assumes:
 - `/metrics` should not be publicly exposed without protection
 - same-domain JobManager UI proxying depends on the app pod being able to reach the in-cluster JobManager REST service; when `status.jobManagerUrl` is missing, the app derives `FlinkDeployment` URLs as `http://<name>-rest.<namespace>.svc:8081/`
 - the v1 JobManager proxy stays read-only and does not support websocket/upgrade flows
+- action-enabled deployments also need `deploy/rbac/api-reader.yaml`, which now grants `get,list,watch,patch,delete` on `flinkdeployments` and `flinksessionjobs`
+- because the example deployment watches `WATCH_NAMESPACES=analytics,payments`, apply the namespace-scoped RBAC manifest in each watched namespace (or adapt it to your cluster-wide RBAC model)
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ This performs:
 - `GET /api/clusters` — list distinct cluster names
 - `GET /api/jobs/{id}` — fetch a job by synthetic ID
 - `GET /api/jobs/{cluster}/{namespace}/{kind}/{name}` — fetch a job by locator
+- `POST /api/jobs/{cluster}/{namespace}/{kind}/{name}/actions/{action}` — execute `cancel`, `suspend`, or `resume` for a single operator-managed resource
 - `GET /api/session` — session bootstrap status for the frontend gate
 
 ### Auth/session routes
@@ -411,8 +412,9 @@ Current CI behavior:
 
 ## Known limitations
 
-- read-only dashboard only; no suspend/cancel/savepoint actions
+- single-resource actions only; bulk actions and savepoints are still out of scope
 - local dev defaults to fixture mode rather than a live cluster
+- fixture mode disables action execution even though it still renders baseline action affordances
 - Flink REST enrichment is best-effort and should never block job listing
 - Flink REST enrichment only calls trusted configured origins (`flinkRestBaseUrl` / `FLINK_REST_BASE_URL`) or the server-derived in-cluster `FlinkDeployment` service URL; status-derived URLs are warning-only for enrichment decisions
 - JobManager UI proxying is read-only and best suited for in-cluster or otherwise app-reachable JobManager URLs; websocket/upgrade flows are not supported in v1

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Flink K8s UI
 
-Read-only web UI for viewing Apache Flink jobs running on Kubernetes.
+v2 baseline web UI for viewing and operating Apache Flink jobs running on Kubernetes.
 
-This project serves a lightweight dashboard that aggregates `FlinkDeployment` and `FlinkSessionJob` resources, normalizes their status into a small UI-friendly contract, and optionally enriches jobs from the Flink REST API.
+This project serves a lightweight dashboard that aggregates `FlinkDeployment` and `FlinkSessionJob` resources, normalizes their status into a small UI-friendly contract, supports single-resource `cancel`/`suspend`/`resume` actions, and optionally enriches jobs from the Flink REST API.
 
 ## What this project does
 
 - lists Flink jobs across one or more Kubernetes namespaces
 - supports both `FlinkDeployment` and `FlinkSessionJob`
 - shows normalized status, health, warnings, and job metadata in a simple browser UI
+- supports single-resource `cancel`, `suspend`, and `resume` actions with immediate post-action refresh
 - optionally enriches jobs with Flink REST overview data
 - serves static UI assets and API routes from a single Rust service
 - supports fixture mode for local development without a cluster
@@ -61,7 +62,8 @@ There is **no separate Node backend runtime path** anymore. Node is used for the
    - Kubernetes Flink operator CRs in live mode
 3. The backend normalizes raw operator resources into a typed public job DTO
 4. Optional Flink REST enrichment adds a small overview summary
-5. The UI renders summary cards, a job table, filters, and a details drawer
+5. The UI renders summary cards, a job table, filters, a details drawer, and authenticated action controls
+6. Job actions post back to the Rust service and immediately refetch the authoritative resource state
 
 ### Main backend components
 
@@ -69,15 +71,16 @@ There is **no separate Node backend runtime path** anymore. Node is used for the
 - `apps/api-rs/src/config.rs` — env/config parsing
 - `apps/api-rs/src/http/router.rs` — routes, auth gate, metrics, static serving
 - `apps/api-rs/src/service/jobs_service.rs` — caching + orchestration
-- `apps/api-rs/src/adapters/k8s.rs` — Kubernetes reads
+- `apps/api-rs/src/http/handlers/jobs.rs` — protected list/action handlers
+- `apps/api-rs/src/adapters/k8s.rs` — Kubernetes reads + action mutations
 - `apps/api-rs/src/adapters/flink.rs` — optional Flink REST enrichment
 - `apps/api-rs/src/domain/normalize.rs` — normalization into the public DTO
 
 ### Frontend components
 
 - `apps/web/public/index.html` — page shell
-- `apps/web/public/app.js` — fetch + UI wiring
-- `apps/web/public/render.js` — rendering helpers and filtering logic
+- `apps/web/public/app.js` — auth bootstrap, fetch, action submission, and UI wiring
+- `apps/web/public/render.js` — rendering helpers, filtering logic, and action controls
 - `apps/web/public/styles.css` — styling
 
 ## Prerequisites
@@ -396,7 +399,7 @@ The included deployment assumes:
 - `deploy/api/deployment.yaml` is a **local port-forward example** until you replace `OIDC_EXTERNAL_BASE_URL=http://localhost:3000` and `SESSION_SECURE_COOKIE=false` with the real HTTPS ingress settings
 - `/metrics` should not be publicly exposed without protection
 - same-domain JobManager UI proxying depends on the app pod being able to reach the in-cluster JobManager REST service; when `status.jobManagerUrl` is missing, the app derives `FlinkDeployment` URLs as `http://<name>-rest.<namespace>.svc:8081/`
-- the v1 JobManager proxy stays read-only and does not support websocket/upgrade flows
+- the JobManager proxy remains read-only in the v2 baseline and does not support websocket/upgrade flows
 - action-enabled deployments also need `deploy/rbac/api-reader.yaml`, which now grants `get,list,watch,patch,delete` on `flinkdeployments` and `flinksessionjobs`
 - because the example deployment watches `WATCH_NAMESPACES=analytics,payments`, apply the namespace-scoped RBAC manifest in each watched namespace (or adapt it to your cluster-wide RBAC model)
 
@@ -420,13 +423,14 @@ Current CI behavior:
 - fixture mode disables action execution even though it still renders baseline action affordances
 - Flink REST enrichment is best-effort and should never block job listing
 - Flink REST enrichment only calls trusted configured origins (`flinkRestBaseUrl` / `FLINK_REST_BASE_URL`) or the server-derived in-cluster `FlinkDeployment` service URL; status-derived URLs are warning-only for enrichment decisions
-- JobManager UI proxying is read-only and best suited for in-cluster or otherwise app-reachable JobManager URLs; websocket/upgrade flows are not supported in v1
+- JobManager UI proxying is read-only and best suited for in-cluster or otherwise app-reachable JobManager URLs; websocket/upgrade flows are not supported in the v2 baseline
 - `FlinkSessionJob` collection is also best-effort
 - production access control depends on correct ingress/reverse-proxy configuration
 
 ## Additional docs
 
-- `docs/architecture/flink-job-ui-v1.md`
+- `docs/architecture/flink-job-ui-v2.md`
+- `docs/architecture/flink-job-ui-v1.md` (historical v1 note)
 - `docs/ops/local-dev.md`
 
 ## License

--- a/apps/api-rs/src/adapters/fixture.rs
+++ b/apps/api-rs/src/adapters/fixture.rs
@@ -21,5 +21,15 @@ pub async fn load_fixture_jobs(config: &AppConfig) -> Result<Vec<Job>> {
         })?;
     let payload: FixtureEnvelope =
         serde_json::from_str(&raw).context("failed to parse fixture JSON payload")?;
-    Ok(payload.jobs)
+    Ok(payload
+        .jobs
+        .into_iter()
+        .map(|mut job| {
+            if job.actions == crate::domain::job::JobActions::default() {
+                job.derive_actions();
+            }
+            job.disable_actions("Actions are unavailable in fixture mode");
+            job
+        })
+        .collect())
 }

--- a/apps/api-rs/src/adapters/flink.rs
+++ b/apps/api-rs/src/adapters/flink.rs
@@ -478,6 +478,7 @@ mod tests {
             flink_job_id: None,
             native_ui_url,
             warnings: Vec::new(),
+            actions: crate::domain::job::JobActions::for_status("running"),
             details: JobDetails::default(),
         }
     }

--- a/apps/api-rs/src/adapters/k8s.rs
+++ b/apps/api-rs/src/adapters/k8s.rs
@@ -3,7 +3,7 @@ use reqwest::Client;
 use serde_json::Value;
 
 use crate::config::ClusterConfig;
-use crate::domain::job::Job;
+use crate::domain::job::{Job, JobAction};
 use crate::domain::normalize::normalize_flink_resource;
 use crate::error::UpstreamHttpError;
 
@@ -24,6 +24,60 @@ pub async fn list_cluster_jobs(
         .chain(session_jobs.into_iter())
         .map(|resource| normalize_flink_resource(resource, cluster))
         .collect())
+}
+
+pub async fn apply_job_action(
+    cluster: &ClusterConfig,
+    namespace: &str,
+    kind: &str,
+    name: &str,
+    action: JobAction,
+    request_timeout_ms: u64,
+) -> Result<()> {
+    let client = build_client(cluster, request_timeout_ms)?;
+    let plural = resource_plural(kind)?;
+    let path = format!(
+        "/apis/flink.apache.org/{}/namespaces/{}/{}/{}",
+        cluster.flink_api_version, namespace, plural, name
+    );
+    let url = format!("{}{}", cluster.api_url.trim_end_matches('/'), path);
+
+    let request = match action {
+        JobAction::Cancel => client.delete(&url),
+        JobAction::Suspend => client
+            .patch(&url)
+            .header("Content-Type", "application/merge-patch+json")
+            .body(r#"{"spec":{"job":{"state":"suspended"}}}"#),
+        JobAction::Resume => client
+            .patch(&url)
+            .header("Content-Type", "application/merge-patch+json")
+            .body(r#"{"spec":{"job":{"state":"running"}}}"#),
+    };
+
+    let response = request
+        .header("Accept", "application/json")
+        .bearer_auth(&cluster.bearer_token)
+        .send()
+        .await
+        .with_context(|| format!("failed to {} {}", action.as_str(), path))?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+
+    if status.is_client_error() || status.is_server_error() {
+        return Err(UpstreamHttpError {
+            status_code: status.as_u16(),
+            message: format!(
+                "Kubernetes API {} for {} {}: {}",
+                status.as_u16(),
+                action.as_str().to_ascii_uppercase(),
+                path,
+                body.chars().take(200).collect::<String>()
+            ),
+        }
+        .into());
+    }
+
+    Ok(())
 }
 
 async fn list_resources_for_plural(
@@ -70,6 +124,14 @@ fn build_namespace_paths(cluster: &ClusterConfig, plural: &str) -> Vec<String> {
             )
         })
         .collect()
+}
+
+fn resource_plural(kind: &str) -> Result<&'static str> {
+    match kind {
+        "FlinkDeployment" => Ok("flinkdeployments"),
+        "FlinkSessionJob" => Ok("flinksessionjobs"),
+        _ => anyhow::bail!("unsupported Flink resource kind `{kind}`"),
+    }
 }
 
 fn build_client(cluster: &ClusterConfig, request_timeout_ms: u64) -> Result<Client> {
@@ -123,12 +185,12 @@ async fn request_json(client: &Client, cluster: &ClusterConfig, path: &str) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
-    use axum::extract::OriginalUri;
-    use axum::http::StatusCode;
+    use axum::extract::{OriginalUri, Request};
+    use axum::http::{Method, StatusCode};
     use axum::response::IntoResponse;
-    use axum::routing::get;
+    use axum::routing::{any, get};
     use axum::{Json, Router};
     use serde_json::json;
     use tokio::net::TcpListener;
@@ -289,6 +351,115 @@ mod tests {
         assert!(!format!("{error:#}").contains("only allowed for localhost or loopback"));
     }
 
+    #[tokio::test]
+    async fn apply_job_action_patches_suspend_state_for_deployments() {
+        let recorder = Arc::new(Mutex::new(Vec::new()));
+        let mock = start_recording_server(
+            vec![(
+                Method::PATCH,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments/orders-stream"
+                    .to_owned(),
+                StatusCode::OK,
+                json!({}),
+            )],
+            Arc::clone(&recorder),
+        )
+        .await;
+        let cluster = cluster(&mock.base_url);
+
+        apply_job_action(
+            &cluster,
+            "analytics",
+            "FlinkDeployment",
+            "orders-stream",
+            JobAction::Suspend,
+            1_000,
+        )
+        .await
+        .expect("suspend should succeed");
+
+        let captured = recorder.lock().expect("recorder should lock");
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].0, Method::PATCH);
+        assert_eq!(
+            captured[0].1,
+            "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments/orders-stream"
+        );
+        assert_eq!(captured[0].2, r#"{"spec":{"job":{"state":"suspended"}}}"#);
+
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn apply_job_action_patches_running_state_for_session_jobs() {
+        let recorder = Arc::new(Mutex::new(Vec::new()));
+        let mock = start_recording_server(
+            vec![(
+                Method::PATCH,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinksessionjobs/settlement-job"
+                    .to_owned(),
+                StatusCode::OK,
+                json!({}),
+            )],
+            Arc::clone(&recorder),
+        )
+        .await;
+        let cluster = cluster(&mock.base_url);
+
+        apply_job_action(
+            &cluster,
+            "analytics",
+            "FlinkSessionJob",
+            "settlement-job",
+            JobAction::Resume,
+            1_000,
+        )
+        .await
+        .expect("resume should succeed");
+
+        let captured = recorder.lock().expect("recorder should lock");
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].0, Method::PATCH);
+        assert_eq!(captured[0].2, r#"{"spec":{"job":{"state":"running"}}}"#);
+
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn apply_job_action_deletes_resources_for_cancel() {
+        let recorder = Arc::new(Mutex::new(Vec::new()));
+        let mock = start_recording_server(
+            vec![(
+                Method::DELETE,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments/orders-stream"
+                    .to_owned(),
+                StatusCode::OK,
+                json!({}),
+            )],
+            Arc::clone(&recorder),
+        )
+        .await;
+        let cluster = cluster(&mock.base_url);
+
+        apply_job_action(
+            &cluster,
+            "analytics",
+            "FlinkDeployment",
+            "orders-stream",
+            JobAction::Cancel,
+            1_000,
+        )
+        .await
+        .expect("cancel should succeed");
+
+        let captured = recorder.lock().expect("recorder should lock");
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].0, Method::DELETE);
+        assert_eq!(captured[0].2, "");
+
+        mock.shutdown();
+    }
+
     struct MockServer {
         base_url: String,
         task: JoinHandle<()>,
@@ -329,6 +500,59 @@ mod tests {
             axum::serve(listener, app)
                 .await
                 .expect("mock server should run");
+        });
+
+        MockServer {
+            base_url: format!("http://{}", address),
+            task,
+        }
+    }
+
+    async fn start_recording_server(
+        responses: Vec<(Method, String, StatusCode, Value)>,
+        recorder: Arc<Mutex<Vec<(Method, String, String)>>>,
+    ) -> MockServer {
+        let responses = Arc::new(responses);
+        let app = Router::new().fallback(any({
+            let responses = Arc::clone(&responses);
+            move |request: Request| {
+                let responses = Arc::clone(&responses);
+                let recorder = Arc::clone(&recorder);
+                async move {
+                    let method = request.method().clone();
+                    let path = request.uri().path().to_owned();
+                    let body = axum::body::to_bytes(request.into_body(), usize::MAX)
+                        .await
+                        .expect("body should read");
+                    recorder.lock().expect("recorder should lock").push((
+                        method.clone(),
+                        path.clone(),
+                        String::from_utf8(body.to_vec()).expect("body should be utf-8"),
+                    ));
+                    match responses
+                        .iter()
+                        .find(|(candidate_method, candidate_path, _, _)| {
+                            candidate_method == &method && candidate_path == &path
+                        }) {
+                        Some((_, _, status, payload)) => {
+                            (*status, Json(payload.clone())).into_response()
+                        }
+                        None => (StatusCode::NOT_FOUND, Json(json!({"error":"not found"})))
+                            .into_response(),
+                    }
+                }
+            }
+        }));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("listener should have local address");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("recording mock server should run");
         });
 
         MockServer {

--- a/apps/api-rs/src/adapters/k8s.rs
+++ b/apps/api-rs/src/adapters/k8s.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use reqwest::Client;
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::config::ClusterConfig;
 use crate::domain::job::{Job, JobAction};
@@ -44,14 +44,25 @@ pub async fn apply_job_action(
 
     let request = match action {
         JobAction::Cancel => client.delete(&url),
-        JobAction::Suspend => client
-            .patch(&url)
-            .header("Content-Type", "application/merge-patch+json")
-            .body(r#"{"spec":{"job":{"state":"suspended"}}}"#),
-        JobAction::Resume => client
-            .patch(&url)
-            .header("Content-Type", "application/merge-patch+json")
-            .body(r#"{"spec":{"job":{"state":"running"}}}"#),
+        JobAction::Suspend | JobAction::Resume => {
+            let state = match action {
+                JobAction::Suspend => "suspended",
+                JobAction::Resume => "running",
+                JobAction::Cancel => unreachable!("cancel is handled in a separate match arm"),
+            };
+            let patch_body = json!({
+                "spec": {
+                    "job": {
+                        "state": state,
+                    }
+                }
+            });
+
+            client
+                .patch(&url)
+                .header("Content-Type", "application/merge-patch+json")
+                .json(&patch_body)
+        }
     };
 
     let response = request
@@ -185,7 +196,7 @@ async fn request_json(client: &Client, cluster: &ClusterConfig, path: &str) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     use axum::extract::{OriginalUri, Request};
     use axum::http::{Method, StatusCode};
@@ -194,6 +205,7 @@ mod tests {
     use axum::{Json, Router};
     use serde_json::json;
     use tokio::net::TcpListener;
+    use tokio::sync::Mutex;
     use tokio::task::JoinHandle;
 
     fn cluster(base_url: &str) -> ClusterConfig {
@@ -378,7 +390,7 @@ mod tests {
         .await
         .expect("suspend should succeed");
 
-        let captured = recorder.lock().expect("recorder should lock");
+        let captured = recorder.lock().await;
         assert_eq!(captured.len(), 1);
         assert_eq!(captured[0].0, Method::PATCH);
         assert_eq!(
@@ -417,7 +429,7 @@ mod tests {
         .await
         .expect("resume should succeed");
 
-        let captured = recorder.lock().expect("recorder should lock");
+        let captured = recorder.lock().await;
         assert_eq!(captured.len(), 1);
         assert_eq!(captured[0].0, Method::PATCH);
         assert_eq!(captured[0].2, r#"{"spec":{"job":{"state":"running"}}}"#);
@@ -452,7 +464,7 @@ mod tests {
         .await
         .expect("cancel should succeed");
 
-        let captured = recorder.lock().expect("recorder should lock");
+        let captured = recorder.lock().await;
         assert_eq!(captured.len(), 1);
         assert_eq!(captured[0].0, Method::DELETE);
         assert_eq!(captured[0].2, "");
@@ -524,7 +536,7 @@ mod tests {
                     let body = axum::body::to_bytes(request.into_body(), usize::MAX)
                         .await
                         .expect("body should read");
-                    recorder.lock().expect("recorder should lock").push((
+                    recorder.lock().await.push((
                         method.clone(),
                         path.clone(),
                         String::from_utf8(body.to_vec()).expect("body should be utf-8"),

--- a/apps/api-rs/src/domain/job.rs
+++ b/apps/api-rs/src/domain/job.rs
@@ -1,4 +1,95 @@
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum JobAction {
+    Cancel,
+    Suspend,
+    Resume,
+}
+
+impl JobAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cancel => "cancel",
+            Self::Suspend => "suspend",
+            Self::Resume => "resume",
+        }
+    }
+}
+
+impl FromStr for JobAction {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "cancel" => Ok(Self::Cancel),
+            "suspend" => Ok(Self::Suspend),
+            "resume" => Ok(Self::Resume),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobActionState {
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobActions {
+    pub cancel: JobActionState,
+    pub suspend: JobActionState,
+    pub resume: JobActionState,
+}
+
+impl JobActions {
+    pub fn for_status(status: &str) -> Self {
+        match status {
+            "suspended" => Self {
+                cancel: enabled_action(),
+                suspend: disabled_action("Already suspended"),
+                resume: enabled_action(),
+            },
+            "running" | "reconciling" => Self {
+                cancel: enabled_action(),
+                suspend: enabled_action(),
+                resume: disabled_action("Resume is only available for suspended resources"),
+            },
+            "failed" | "unknown" => Self {
+                cancel: enabled_action(),
+                suspend: disabled_action("Suspend is only available for active resources"),
+                resume: disabled_action("Resume is only available for suspended resources"),
+            },
+            _ => Self {
+                cancel: enabled_action(),
+                suspend: disabled_action("Suspend is not available for this resource state"),
+                resume: disabled_action("Resume is not available for this resource state"),
+            },
+        }
+    }
+
+    pub fn disable_all(mut self, reason: &str) -> Self {
+        for state in [&mut self.cancel, &mut self.suspend, &mut self.resume] {
+            state.enabled = false;
+            state.reason = Some(reason.to_owned());
+        }
+        self
+    }
+
+    pub fn state_for(&self, action: JobAction) -> &JobActionState {
+        match action {
+            JobAction::Cancel => &self.cancel,
+            JobAction::Suspend => &self.suspend,
+            JobAction::Resume => &self.resume,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -20,7 +111,19 @@ pub struct Job {
     pub flink_job_id: Option<String>,
     pub native_ui_url: Option<String>,
     pub warnings: Vec<String>,
+    #[serde(default)]
+    pub actions: JobActions,
     pub details: JobDetails,
+}
+
+impl Job {
+    pub fn derive_actions(&mut self) {
+        self.actions = JobActions::for_status(&self.status);
+    }
+
+    pub fn disable_actions(&mut self, reason: &str) {
+        self.actions = self.actions.clone().disable_all(reason);
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -61,4 +164,18 @@ pub struct FlinkRestOverview {
     pub state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub started_at: Option<String>,
+}
+
+fn enabled_action() -> JobActionState {
+    JobActionState {
+        enabled: true,
+        reason: None,
+    }
+}
+
+fn disabled_action(reason: &str) -> JobActionState {
+    JobActionState {
+        enabled: false,
+        reason: Some(reason.to_owned()),
+    }
 }

--- a/apps/api-rs/src/domain/job.rs
+++ b/apps/api-rs/src/domain/job.rs
@@ -74,7 +74,7 @@ impl JobActions {
         }
     }
 
-    pub fn disable_all(mut self, reason: &str) -> Self {
+    pub fn disable_all(&mut self, reason: &str) -> &mut Self {
         for state in [&mut self.cancel, &mut self.suspend, &mut self.resume] {
             state.enabled = false;
             state.reason = Some(reason.to_owned());
@@ -122,7 +122,7 @@ impl Job {
     }
 
     pub fn disable_actions(&mut self, reason: &str) {
-        self.actions = self.actions.clone().disable_all(reason);
+        self.actions.disable_all(reason);
     }
 }
 

--- a/apps/api-rs/src/domain/normalize.rs
+++ b/apps/api-rs/src/domain/normalize.rs
@@ -137,7 +137,7 @@ fn normalize_base(
         .and_then(|value| value_to_string(Some(value))),
     };
 
-    Job {
+    let mut job = Job {
         id: format!("{}:{}:{}:{}", cluster.name, namespace, kind, resource_name),
         cluster: cluster.name.clone(),
         namespace,
@@ -170,11 +170,14 @@ fn normalize_base(
         flink_job_id: None,
         native_ui_url,
         warnings: build_warnings(&status),
+        actions: crate::domain::job::JobActions::default(),
         details: JobDetails {
             status_summary: (!status_summary.is_empty()).then_some(status_summary),
             flink_rest_overview: None,
         },
-    }
+    };
+    job.derive_actions();
+    job
 }
 
 struct StatusInfo {

--- a/apps/api-rs/src/domain/normalize.rs
+++ b/apps/api-rs/src/domain/normalize.rs
@@ -198,6 +198,18 @@ fn canonicalize_status(raw_values: Vec<String>) -> StatusInfo {
         };
     }
 
+    // Operator-managed suspends intentionally tear down the running job and its
+    // JobManager. That can surface transient/expected `FINISHED` or `MISSING`
+    // markers alongside an explicit suspended desired/lifecycle state, but the
+    // resource is still resumable and should be treated as suspended.
+    if normalized.contains("suspend") {
+        return StatusInfo {
+            status: "suspended".to_owned(),
+            health: "warning".to_owned(),
+            raw_status: raw,
+        };
+    }
+
     if ["error", "fail", "missing"]
         .iter()
         .any(|needle| normalized.contains(needle))
@@ -205,14 +217,6 @@ fn canonicalize_status(raw_values: Vec<String>) -> StatusInfo {
         return StatusInfo {
             status: "failed".to_owned(),
             health: "error".to_owned(),
-            raw_status: raw,
-        };
-    }
-
-    if normalized.contains("suspend") {
-        return StatusInfo {
-            status: "suspended".to_owned(),
-            health: "warning".to_owned(),
             raw_status: raw,
         };
     }
@@ -464,6 +468,63 @@ mod tests {
             Some("SUSPENDED")
         );
         assert!(normalized.native_ui_url.is_none());
+    }
+
+    #[test]
+    fn normalize_flink_deployment_keeps_suspended_status_when_jobmanager_is_missing() {
+        let resource = json!({
+            "kind": "FlinkDeployment",
+            "metadata": {
+                "name": "basic-example",
+                "namespace": "flink"
+            },
+            "spec": {
+                "job": {
+                    "name": "basic-example",
+                    "state": "suspended"
+                }
+            },
+            "status": {
+                "jobStatus": { "state": "FINISHED" },
+                "lifecycleState": "SUSPENDED",
+                "jobManagerDeploymentStatus": "MISSING",
+                "reconciliationStatus": { "state": "DEPLOYED" }
+            }
+        });
+
+        let normalized = normalize_flink_deployment(resource, &cluster());
+
+        assert_eq!(normalized.status, "suspended");
+        assert_eq!(normalized.health, "warning");
+        assert_eq!(normalized.actions.suspend.enabled, false);
+        assert_eq!(normalized.actions.resume.enabled, true);
+    }
+
+    #[test]
+    fn normalize_flink_deployment_still_marks_unsuspended_missing_state_as_failed() {
+        let resource = json!({
+            "kind": "FlinkDeployment",
+            "metadata": {
+                "name": "broken-example",
+                "namespace": "flink"
+            },
+            "spec": {
+                "job": {
+                    "name": "broken-example",
+                    "state": "running"
+                }
+            },
+            "status": {
+                "jobStatus": { "state": "FINISHED" },
+                "jobManagerDeploymentStatus": "MISSING",
+                "reconciliationStatus": { "state": "DEPLOYED" }
+            }
+        });
+
+        let normalized = normalize_flink_deployment(resource, &cluster());
+
+        assert_eq!(normalized.status, "failed");
+        assert_eq!(normalized.actions.resume.enabled, false);
     }
 
     #[test]

--- a/apps/api-rs/src/http/handlers/jobs.rs
+++ b/apps/api-rs/src/http/handlers/jobs.rs
@@ -144,18 +144,19 @@ pub async fn post_job_action(
         return Err(conflict("Action unavailable", FIXTURE_MODE_ACTION_DETAILS));
     }
 
+    let cluster_config = cluster_config(&state, &cluster).ok_or_else(|| {
+        internal_message(
+            "Cluster not found",
+            "The specified cluster does not exist",
+            StatusCode::NOT_FOUND,
+        )
+    })?;
+
     let job = state
         .jobs_service
-        .list_jobs(true)
+        .get_job_by_locator_with_refresh(&cluster, &namespace, &kind, &name, true)
         .await
         .map_err(|error| internal_error("Failed to fetch job", error))?
-        .into_iter()
-        .find(|job| {
-            job.cluster == cluster
-                && job.namespace == namespace
-                && job.kind == kind
-                && job.resource_name == name
-        })
         .ok_or_else(|| not_found("Job not found"))?;
 
     let action_state = job.actions.state_for(action);
@@ -168,13 +169,6 @@ pub async fn post_job_action(
         ));
     }
 
-    let cluster_config = cluster_config(&state, &cluster).ok_or_else(|| {
-        internal_message(
-            "Failed to execute action",
-            PUBLIC_INTERNAL_ERROR_DETAILS,
-            StatusCode::INTERNAL_SERVER_ERROR,
-        )
-    })?;
     apply_job_action(
         cluster_config,
         &namespace,
@@ -188,16 +182,9 @@ pub async fn post_job_action(
 
     let refreshed_job = state
         .jobs_service
-        .list_jobs(true)
+        .get_job_by_locator_with_refresh(&cluster, &namespace, &kind, &name, true)
         .await
-        .map_err(|error| internal_error("Failed to refresh jobs", error))?
-        .into_iter()
-        .find(|job| {
-            job.cluster == cluster
-                && job.namespace == namespace
-                && job.kind == kind
-                && job.resource_name == name
-        });
+        .map_err(|error| internal_error("Failed to refresh jobs", error))?;
     let deleted = action == JobAction::Cancel && refreshed_job.is_none();
 
     Ok(Json(JobActionResponse {

--- a/apps/api-rs/src/http/handlers/jobs.rs
+++ b/apps/api-rs/src/http/handlers/jobs.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::collections::BTreeSet;
+use std::str::FromStr;
 
 use axum::Json;
 use axum::extract::{Path, State};
@@ -7,7 +8,9 @@ use axum::http::StatusCode;
 use serde::Serialize;
 use tracing::error;
 
-use crate::domain::job::Job;
+use crate::adapters::k8s::apply_job_action;
+use crate::config::ClusterConfig;
+use crate::domain::job::{Job, JobAction};
 use crate::error::UpstreamHttpError;
 use crate::http::handlers::health::utc_now_string;
 use crate::state::AppState;
@@ -42,6 +45,16 @@ pub struct JobResponse {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobActionResponse {
+    action: String,
+    deleted: bool,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    job: Option<Job>,
+}
+
+#[derive(Serialize)]
 pub struct ErrorResponse {
     error: String,
     details: Cow<'static, str>,
@@ -51,6 +64,7 @@ const PUBLIC_UPSTREAM_ERROR_DETAILS: &str =
     "The upstream request failed; check server logs for details";
 const PUBLIC_INTERNAL_ERROR_DETAILS: &str =
     "The server could not complete the request; check server logs for details";
+const FIXTURE_MODE_ACTION_DETAILS: &str = "Actions are unavailable in fixture mode";
 
 pub async fn list_jobs(
     State(state): State<AppState>,
@@ -120,6 +134,80 @@ pub async fn get_job_by_locator(
     }
 }
 
+pub async fn post_job_action(
+    State(state): State<AppState>,
+    Path((cluster, namespace, kind, name, action)): Path<(String, String, String, String, String)>,
+) -> Result<Json<JobActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let action = JobAction::from_str(&action).map_err(|_| invalid_action())?;
+
+    if state.config.fixture_mode {
+        return Err(conflict("Action unavailable", FIXTURE_MODE_ACTION_DETAILS));
+    }
+
+    let job = state
+        .jobs_service
+        .list_jobs(true)
+        .await
+        .map_err(|error| internal_error("Failed to fetch job", error))?
+        .into_iter()
+        .find(|job| {
+            job.cluster == cluster
+                && job.namespace == namespace
+                && job.kind == kind
+                && job.resource_name == name
+        })
+        .ok_or_else(|| not_found("Job not found"))?;
+
+    let action_state = job.actions.state_for(action);
+    if !action_state.enabled {
+        return Err(conflict(
+            "Action not allowed",
+            action_state.reason.clone().unwrap_or_else(|| {
+                "This action is not available for the current resource state".to_owned()
+            }),
+        ));
+    }
+
+    let cluster_config = cluster_config(&state, &cluster).ok_or_else(|| {
+        internal_message(
+            "Failed to execute action",
+            PUBLIC_INTERNAL_ERROR_DETAILS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+    })?;
+    apply_job_action(
+        cluster_config,
+        &namespace,
+        &kind,
+        &name,
+        action,
+        state.config.request_timeout_ms,
+    )
+    .await
+    .map_err(|error| internal_error("Failed to execute action", error))?;
+
+    let refreshed_job = state
+        .jobs_service
+        .list_jobs(true)
+        .await
+        .map_err(|error| internal_error("Failed to refresh jobs", error))?
+        .into_iter()
+        .find(|job| {
+            job.cluster == cluster
+                && job.namespace == namespace
+                && job.kind == kind
+                && job.resource_name == name
+        });
+    let deleted = action == JobAction::Cancel && refreshed_job.is_none();
+
+    Ok(Json(JobActionResponse {
+        action: action.as_str().to_owned(),
+        deleted,
+        message: action_message(action, deleted),
+        job: refreshed_job,
+    }))
+}
+
 fn internal_error(message: &str, error: anyhow::Error) -> (StatusCode, Json<ErrorResponse>) {
     let status_code = error
         .downcast_ref::<UpstreamHttpError>()
@@ -160,6 +248,52 @@ fn public_error_details(error: &anyhow::Error) -> Cow<'static, str> {
     } else {
         Cow::Borrowed(PUBLIC_INTERNAL_ERROR_DETAILS)
     }
+}
+
+fn conflict(
+    message: &'static str,
+    details: impl Into<Cow<'static, str>>,
+) -> (StatusCode, Json<ErrorResponse>) {
+    internal_message(message, details, StatusCode::CONFLICT)
+}
+
+fn invalid_action() -> (StatusCode, Json<ErrorResponse>) {
+    internal_message(
+        "Invalid action",
+        "Supported actions are cancel, suspend, and resume",
+        StatusCode::BAD_REQUEST,
+    )
+}
+
+fn internal_message(
+    message: &'static str,
+    details: impl Into<Cow<'static, str>>,
+    status: StatusCode,
+) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        status,
+        Json(ErrorResponse {
+            error: message.to_owned(),
+            details: details.into(),
+        }),
+    )
+}
+
+fn action_message(action: JobAction, deleted: bool) -> String {
+    match action {
+        JobAction::Cancel if deleted => "Resource deleted successfully".to_owned(),
+        JobAction::Cancel => "Cancel action completed".to_owned(),
+        JobAction::Suspend => "Resource suspended successfully".to_owned(),
+        JobAction::Resume => "Resource resumed successfully".to_owned(),
+    }
+}
+
+fn cluster_config<'a>(state: &'a AppState, cluster_name: &str) -> Option<&'a ClusterConfig> {
+    state
+        .config
+        .clusters
+        .iter()
+        .find(|cluster| cluster.name == cluster_name)
 }
 
 fn format_error_chain(error: &anyhow::Error) -> String {

--- a/apps/api-rs/src/http/handlers/jobs.rs
+++ b/apps/api-rs/src/http/handlers/jobs.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use axum::Json;
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use serde::Serialize;
 use tracing::error;
 
@@ -65,6 +65,7 @@ const PUBLIC_UPSTREAM_ERROR_DETAILS: &str =
 const PUBLIC_INTERNAL_ERROR_DETAILS: &str =
     "The server could not complete the request; check server logs for details";
 const FIXTURE_MODE_ACTION_DETAILS: &str = "Actions are unavailable in fixture mode";
+const ACTION_CSRF_HEADER: &str = "x-csrf-token";
 
 pub async fn list_jobs(
     State(state): State<AppState>,
@@ -136,6 +137,7 @@ pub async fn get_job_by_locator(
 
 pub async fn post_job_action(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path((cluster, namespace, kind, name, action)): Path<(String, String, String, String, String)>,
 ) -> Result<Json<JobActionResponse>, (StatusCode, Json<ErrorResponse>)> {
     let action = JobAction::from_str(&action).map_err(|_| invalid_action())?;
@@ -143,6 +145,8 @@ pub async fn post_job_action(
     if state.config.fixture_mode {
         return Err(conflict("Action unavailable", FIXTURE_MODE_ACTION_DETAILS));
     }
+
+    validate_action_csrf(&state, &headers).await?;
 
     let cluster_config = cluster_config(&state, &cluster).ok_or_else(|| {
         internal_message(
@@ -281,6 +285,52 @@ fn cluster_config<'a>(state: &'a AppState, cluster_name: &str) -> Option<&'a Clu
         .clusters
         .iter()
         .find(|cluster| cluster.name == cluster_name)
+}
+
+async fn validate_action_csrf(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let provided_csrf = headers
+        .get(ACTION_CSRF_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            internal_message(
+                "Invalid CSRF token",
+                "A valid CSRF token is required for job actions",
+                StatusCode::FORBIDDEN,
+            )
+        })?;
+
+    let session = state
+        .auth
+        .session_from_headers(&state.config, headers)
+        .await
+        .map_err(|_| {
+            internal_message(
+                "Failed to validate session",
+                PUBLIC_INTERNAL_ERROR_DETAILS,
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+        })?
+        .ok_or_else(|| {
+            internal_message(
+                "Missing or expired session",
+                "A valid session is required for job actions",
+                StatusCode::UNAUTHORIZED,
+            )
+        })?;
+
+    if session.csrf_token == provided_csrf {
+        Ok(())
+    } else {
+        Err(internal_message(
+            "Invalid CSRF token",
+            "A valid CSRF token is required for job actions",
+            StatusCode::FORBIDDEN,
+        ))
+    }
 }
 
 fn format_error_chain(error: &anyhow::Error) -> String {

--- a/apps/api-rs/src/http/router.rs
+++ b/apps/api-rs/src/http/router.rs
@@ -10,7 +10,9 @@ use tower_http::services::ServeFile;
 use crate::http::handlers::auth::{callback, login, logout, session_status};
 use crate::http::handlers::health::{healthz, readyz};
 use crate::http::handlers::jobmanager_proxy::{proxy_jobmanager_path, proxy_jobmanager_root};
-use crate::http::handlers::jobs::{get_clusters, get_job_by_id, get_job_by_locator, list_jobs};
+use crate::http::handlers::jobs::{
+    get_clusters, get_job_by_id, get_job_by_locator, list_jobs, post_job_action,
+};
 use crate::state::AppState;
 
 pub fn build_router(state: AppState) -> Router {
@@ -42,6 +44,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/api/jobs/{cluster}/{namespace}/{kind}/{name}",
             get(get_job_by_locator),
+        )
+        .route(
+            "/api/jobs/{cluster}/{namespace}/{kind}/{name}/actions/{action}",
+            post(post_job_action),
         )
         .route("/api/jobs/{id}", get(get_job_by_id))
         .route(
@@ -139,6 +145,9 @@ fn route_label(method: &str, matched_path: Option<&str>) -> String {
         ("GET", Some("/api/clusters")) => "getClusters",
         ("GET", Some("/api/jobs/{id}"))
         | ("GET", Some("/api/jobs/{cluster}/{namespace}/{kind}/{name}")) => "getJob",
+        ("POST", Some("/api/jobs/{cluster}/{namespace}/{kind}/{name}/actions/{action}")) => {
+            "jobAction"
+        }
         ("GET", Some("/api/jobs/{id}/jobmanager-proxy"))
         | ("GET", Some("/api/jobs/{id}/jobmanager-proxy/"))
         | ("GET", Some("/api/jobs/{id}/jobmanager-proxy/{*path}")) => "jobManagerProxy",
@@ -160,11 +169,12 @@ mod tests {
     use std::fs;
     use std::net::TcpListener as StdTcpListener;
     use std::path::PathBuf;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
-    use axum::extract::OriginalUri;
-    use axum::http::{StatusCode, header};
+    use axum::extract::{OriginalUri, Request};
+    use axum::http::{Method, StatusCode, header};
     use axum::response::IntoResponse;
+    use axum::routing::any;
     use axum::{Json, Router};
     use reqwest::{Client, RequestBuilder, redirect::Policy};
     use serde_json::{Value, json};
@@ -618,6 +628,26 @@ mod tests {
         assert!(detail_payload["job"]["details"].get("metadata").is_none());
         assert!(detail_payload["job"]["details"].get("spec").is_none());
         assert!(detail_payload["job"]["details"].get("status").is_none());
+        assert_eq!(detail_payload["job"]["actions"]["cancel"]["enabled"], false);
+        assert_eq!(
+            detail_payload["job"]["actions"]["cancel"]["reason"],
+            "Actions are unavailable in fixture mode"
+        );
+
+        let action_response = client
+            .post(format!(
+                "{}/api/jobs/demo/analytics/FlinkDeployment/orders-stream/actions/suspend",
+                app.base_url
+            ))
+            .send()
+            .await
+            .expect("fixture action response should succeed");
+        assert_eq!(action_response.status(), StatusCode::CONFLICT);
+        let action_payload: Value = action_response
+            .json()
+            .await
+            .expect("fixture action payload should be JSON");
+        assert_eq!(action_payload["error"], "Action unavailable");
 
         let healthz_response = client
             .get(format!("{}/healthz", app.base_url))
@@ -653,11 +683,12 @@ mod tests {
             .json()
             .await
             .expect("metrics payload should be JSON");
-        assert_eq!(metrics_payload["requestsTotal"], 6);
-        assert_eq!(metrics_payload["errorsTotal"], 0);
+        assert_eq!(metrics_payload["requestsTotal"], 7);
+        assert_eq!(metrics_payload["errorsTotal"], 1);
         assert_eq!(
             metrics_payload["routes"],
             json!({
+              "jobAction": 1,
               "getClusters": 1,
               "getJob": 1,
               "healthz": 1,
@@ -863,6 +894,16 @@ mod tests {
             .expect("detail unauthorized response should succeed");
         assert_eq!(detail_response.status(), StatusCode::UNAUTHORIZED);
 
+        let action_response = client
+            .post(format!(
+                "{}/api/jobs/demo/analytics/FlinkDeployment/orders-stream/actions/suspend",
+                app.base_url
+            ))
+            .send()
+            .await
+            .expect("action unauthorized response should succeed");
+        assert_eq!(action_response.status(), StatusCode::UNAUTHORIZED);
+
         let healthz_response = client
             .get(format!("{}/healthz", app.base_url))
             .send()
@@ -880,6 +921,128 @@ mod tests {
         app.shutdown();
         kubernetes.shutdown();
         flink.shutdown();
+    }
+
+    #[tokio::test]
+    async fn live_mode_action_route_updates_resource_and_returns_refreshed_job() {
+        let kubernetes = start_stateful_json_server(vec![
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments",
+                StatusCode::OK,
+                json!({
+                  "items": [{
+                    "kind": "FlinkDeployment",
+                    "metadata": {"name": "orders-stream", "namespace": "analytics"},
+                    "spec": {"job": {"name": "orders-stream", "state": "running"}},
+                    "status": {"jobStatus": {"state": "RUNNING"}}
+                  }]
+                }),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinksessionjobs",
+                StatusCode::OK,
+                json!({"items":[]}),
+            ),
+            MethodJsonResponse::new(
+                Method::PATCH,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments/orders-stream",
+                StatusCode::OK,
+                json!({}),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments",
+                StatusCode::OK,
+                json!({
+                  "items": [{
+                    "kind": "FlinkDeployment",
+                    "metadata": {"name": "orders-stream", "namespace": "analytics"},
+                    "spec": {"job": {"name": "orders-stream", "state": "suspended"}},
+                    "status": {"jobStatus": {"state": "SUSPENDED"}}
+                  }]
+                }),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinksessionjobs",
+                StatusCode::OK,
+                json!({"items":[]}),
+            ),
+        ])
+        .await;
+        let app = start_app(live_config(&kubernetes.base_url, None)).await;
+        let client = Client::new();
+
+        let response = authorized(
+            &app,
+            client.post(format!(
+                "{}/api/jobs/demo/analytics/FlinkDeployment/orders-stream/actions/suspend",
+                app.base_url
+            )),
+        )
+        .send()
+        .await
+        .expect("action response should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload: Value = response
+            .json()
+            .await
+            .expect("action payload should be JSON");
+        assert_eq!(payload["action"], "suspend");
+        assert_eq!(payload["deleted"], false);
+        assert_eq!(payload["job"]["status"], "suspended");
+        assert_eq!(payload["job"]["actions"]["resume"]["enabled"], true);
+
+        app.shutdown();
+        kubernetes.shutdown();
+    }
+
+    #[tokio::test]
+    async fn live_mode_action_route_returns_conflict_for_disabled_actions() {
+        let kubernetes = start_stateful_json_server(vec![
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments",
+                StatusCode::OK,
+                json!({"items":[]}),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinksessionjobs",
+                StatusCode::OK,
+                json!({
+                  "items": [{
+                    "kind": "FlinkSessionJob",
+                    "metadata": {"name": "settlement-job", "namespace": "analytics"},
+                    "spec": {"job": {"state": "suspended", "jarURI": "local:///example.jar"}},
+                    "status": {"jobStatus": {"state": "SUSPENDED"}}
+                  }]
+                }),
+            ),
+        ])
+        .await;
+        let app = start_app(live_config(&kubernetes.base_url, None)).await;
+        let client = Client::new();
+
+        let response = authorized(
+            &app,
+            client.post(format!(
+                "{}/api/jobs/demo/analytics/FlinkSessionJob/settlement-job/actions/suspend",
+                app.base_url
+            )),
+        )
+        .send()
+        .await
+        .expect("action response should succeed");
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let payload: Value = response.json().await.expect("payload should be JSON");
+        assert_eq!(payload["error"], "Action not allowed");
+        assert_eq!(payload["details"], "Already suspended");
+
+        app.shutdown();
+        kubernetes.shutdown();
     }
 
     #[tokio::test]
@@ -1283,6 +1446,60 @@ mod tests {
         }
     }
 
+    async fn start_stateful_json_server(responses: Vec<MethodJsonResponse>) -> RunningServer {
+        let responses = Arc::new(Mutex::new(responses.into_iter().fold(
+            BTreeMap::<String, Vec<(StatusCode, Value)>>::new(),
+            |mut entries, response| {
+                entries
+                    .entry(response.key())
+                    .or_default()
+                    .push((response.status, response.payload));
+                entries
+            },
+        )));
+        let app = Router::new().fallback(any({
+            let responses = Arc::clone(&responses);
+            move |request: Request| {
+                let responses = Arc::clone(&responses);
+                async move {
+                    let key = format!("{} {}", request.method(), request.uri().path());
+                    let _ = axum::body::to_bytes(request.into_body(), usize::MAX)
+                        .await
+                        .expect("request body should read");
+                    let mut responses = responses.lock().expect("responses should lock");
+                    match responses.get_mut(&key).and_then(|values| {
+                        if values.is_empty() {
+                            None
+                        } else {
+                            Some(values.remove(0))
+                        }
+                    }) {
+                        Some((status, payload)) => (status, Json(payload)).into_response(),
+                        None => (StatusCode::NOT_FOUND, Json(json!({"error":"not found"})))
+                            .into_response(),
+                    }
+                }
+            }
+        }));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("listener should have local address");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("stateful mock server should run");
+        });
+
+        RunningServer {
+            base_url: format!("http://{}", address),
+            session_cookie: None,
+            task,
+        }
+    }
+
     async fn start_mock_http_server(responses: Vec<MockHttpResponse>) -> RunningServer {
         let responses = Arc::new(
             responses
@@ -1487,12 +1704,44 @@ mod tests {
         }
     }
 
+    struct MethodJsonResponse {
+        method: Method,
+        path: String,
+        status: StatusCode,
+        payload: Value,
+    }
+
+    impl MethodJsonResponse {
+        fn new(method: Method, path: &str, status: StatusCode, payload: Value) -> Self {
+            Self {
+                method,
+                path: path.to_owned(),
+                status,
+                payload,
+            }
+        }
+
+        fn key(&self) -> String {
+            format!("{} {}", self.method, self.path)
+        }
+    }
+
     fn load_fixture_jobs() -> Vec<Value> {
         let fixture_path = workspace_root().join("fixtures/jobs.json");
-        let payload: Value = serde_json::from_str(
+        let mut payload: Value = serde_json::from_str(
             &fs::read_to_string(fixture_path).expect("fixture file should be readable"),
         )
         .expect("fixture JSON should parse");
+        if let Some(jobs) = payload["jobs"].as_array_mut() {
+            for job in jobs {
+                for action_name in ["cancel", "suspend", "resume"] {
+                    if let Some(action) = job["actions"].get_mut(action_name) {
+                        action["enabled"] = json!(false);
+                        action["reason"] = json!("Actions are unavailable in fixture mode");
+                    }
+                }
+            }
+        }
         payload["jobs"]
             .as_array()
             .expect("fixture jobs should be an array")

--- a/apps/api-rs/src/http/router.rs
+++ b/apps/api-rs/src/http/router.rs
@@ -169,7 +169,7 @@ mod tests {
     use std::fs;
     use std::net::TcpListener as StdTcpListener;
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     use axum::extract::{OriginalUri, Request};
     use axum::http::{Method, StatusCode, header};
@@ -179,6 +179,7 @@ mod tests {
     use reqwest::{Client, RequestBuilder, redirect::Policy};
     use serde_json::{Value, json};
     use tokio::net::TcpListener;
+    use tokio::sync::Mutex;
     use tokio::task::JoinHandle;
 
     use super::build_router;
@@ -1046,6 +1047,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn live_mode_action_route_returns_not_found_for_unknown_cluster() {
+        let kubernetes = start_stateful_json_server(vec![
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments",
+                StatusCode::OK,
+                json!({"items":[]}),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinksessionjobs",
+                StatusCode::OK,
+                json!({"items":[]}),
+            ),
+        ])
+        .await;
+        let app = start_app(live_config(&kubernetes.base_url, None)).await;
+        let client = Client::new();
+
+        let response = authorized(
+            &app,
+            client.post(format!(
+                "{}/api/jobs/prod/analytics/FlinkDeployment/orders-stream/actions/suspend",
+                app.base_url
+            )),
+        )
+        .send()
+        .await
+        .expect("action response should succeed");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let payload: Value = response.json().await.expect("payload should be JSON");
+        assert_eq!(payload["error"], "Cluster not found");
+        assert_eq!(payload["details"], "The specified cluster does not exist");
+
+        app.shutdown();
+        kubernetes.shutdown();
+    }
+
+    #[tokio::test]
     async fn live_mode_serves_shell_assets_without_auth_headers() {
         let flink = start_mock_json_server(vec![(
             "/jobs/overview".to_owned(),
@@ -1466,7 +1506,7 @@ mod tests {
                     let _ = axum::body::to_bytes(request.into_body(), usize::MAX)
                         .await
                         .expect("request body should read");
-                    let mut responses = responses.lock().expect("responses should lock");
+                    let mut responses = responses.lock().await;
                     match responses.get_mut(&key).and_then(|values| {
                         if values.is_empty() {
                             None

--- a/apps/api-rs/src/http/router.rs
+++ b/apps/api-rs/src/http/router.rs
@@ -1,11 +1,13 @@
+use std::io::ErrorKind;
+
+use axum::body::Body;
 use axum::extract::{MatchedPath, Request, State};
-use axum::http::StatusCode;
+use axum::http::{StatusCode, header};
 use axum::middleware::{Next, from_fn_with_state};
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, get_service, post};
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Serialize;
-use tower_http::services::ServeFile;
 
 use crate::http::handlers::auth::{callback, login, logout, session_status};
 use crate::http::handlers::health::{healthz, readyz};
@@ -15,29 +17,17 @@ use crate::http::handlers::jobs::{
 };
 use crate::state::AppState;
 
+const SHELL_HTML_CACHE_CONTROL: &str = "no-store";
+const VERSIONED_SHELL_ASSET_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+const FAVICON_CACHE_CONTROL: &str = "no-cache";
+
 pub fn build_router(state: AppState) -> Router {
-    let static_dir = state.config.static_dir();
     let public_shell = Router::new()
-        .route_service(
-            "/",
-            get_service(ServeFile::new(state.config.index_html_path())),
-        )
-        .route_service(
-            "/app.js",
-            get_service(ServeFile::new(static_dir.join("app.js"))),
-        )
-        .route_service(
-            "/render.js",
-            get_service(ServeFile::new(static_dir.join("render.js"))),
-        )
-        .route_service(
-            "/styles.css",
-            get_service(ServeFile::new(static_dir.join("styles.css"))),
-        )
-        .route_service(
-            "/favicon.ico",
-            get_service(ServeFile::new(static_dir.join("favicon.ico"))),
-        );
+        .route("/", get(shell_index_html))
+        .route("/app.js", get(shell_app_js))
+        .route("/render.js", get(shell_render_js))
+        .route("/styles.css", get(shell_styles_css))
+        .route("/favicon.ico", get(shell_favicon));
     let protected_api = Router::new()
         .route("/api/jobs", get(list_jobs))
         .route("/api/clusters", get(get_clusters))
@@ -76,6 +66,113 @@ pub fn build_router(state: AppState) -> Router {
         .route("/readyz", get(readyz))
         .layer(from_fn_with_state(state.clone(), track_requests))
         .with_state(state)
+}
+
+async fn shell_index_html(State(state): State<AppState>) -> Response {
+    let template = match tokio::fs::read_to_string(state.config.index_html_path()).await {
+        Ok(template) => template,
+        Err(error) => return file_error_response(error),
+    };
+    let html = render_index_html(&template, &state.shell_asset_version);
+
+    build_static_response(
+        StatusCode::OK,
+        "text/html; charset=utf-8",
+        SHELL_HTML_CACHE_CONTROL,
+        html.into_bytes(),
+    )
+}
+
+async fn shell_app_js(State(state): State<AppState>) -> Response {
+    match tokio::fs::read_to_string(state.config.static_dir().join("app.js")).await {
+        Ok(source) => build_static_response(
+            StatusCode::OK,
+            "text/javascript; charset=utf-8",
+            VERSIONED_SHELL_ASSET_CACHE_CONTROL,
+            rewrite_app_js(&source, &state.shell_asset_version).into_bytes(),
+        ),
+        Err(error) => file_error_response(error),
+    }
+}
+
+async fn shell_render_js(State(state): State<AppState>) -> Response {
+    serve_static_asset(
+        state.config.static_dir().join("render.js"),
+        "text/javascript; charset=utf-8",
+        VERSIONED_SHELL_ASSET_CACHE_CONTROL,
+    )
+    .await
+}
+
+async fn shell_styles_css(State(state): State<AppState>) -> Response {
+    serve_static_asset(
+        state.config.static_dir().join("styles.css"),
+        "text/css; charset=utf-8",
+        VERSIONED_SHELL_ASSET_CACHE_CONTROL,
+    )
+    .await
+}
+
+async fn shell_favicon(State(state): State<AppState>) -> Response {
+    serve_static_asset(
+        state.config.static_dir().join("favicon.ico"),
+        "image/x-icon",
+        FAVICON_CACHE_CONTROL,
+    )
+    .await
+}
+
+async fn serve_static_asset(
+    path: std::path::PathBuf,
+    content_type: &'static str,
+    cache_control: &'static str,
+) -> Response {
+    match tokio::fs::read(path).await {
+        Ok(contents) => {
+            build_static_response(StatusCode::OK, content_type, cache_control, contents)
+        }
+        Err(error) => file_error_response(error),
+    }
+}
+
+fn render_index_html(template: &str, asset_version: &str) -> String {
+    let styles_href = format!(r#"href="/styles.css?v={asset_version}""#);
+    let script_src = format!(r#"<script type="module" src="/app.js?v={asset_version}"></script>"#);
+
+    template
+        .replace(r#"href="/styles.css""#, &styles_href)
+        .replace(
+            r#"<script type="module" src="/app.js"></script>"#,
+            &script_src,
+        )
+}
+
+fn rewrite_app_js(source: &str, asset_version: &str) -> String {
+    source.replacen("./render.js", &format!("./render.js?v={asset_version}"), 1)
+}
+
+fn build_static_response(
+    status: StatusCode,
+    content_type: &'static str,
+    cache_control: &'static str,
+    body: Vec<u8>,
+) -> Response {
+    (
+        status,
+        [
+            (header::CONTENT_TYPE, content_type),
+            (header::CACHE_CONTROL, cache_control),
+        ],
+        Body::from(body),
+    )
+        .into_response()
+}
+
+fn file_error_response(error: std::io::Error) -> Response {
+    match error.kind() {
+        ErrorKind::NotFound => StatusCode::NOT_FOUND.into_response(),
+        _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
 }
 
 async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
@@ -1047,6 +1144,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn live_mode_resume_allows_suspended_resources_with_missing_jobmanager_signals() {
+        let kubernetes = start_stateful_json_server(vec![
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments",
+                StatusCode::OK,
+                json!({
+                  "items": [{
+                    "kind": "FlinkDeployment",
+                    "metadata": {"name": "orders-stream", "namespace": "analytics"},
+                    "spec": {"job": {"name": "orders-stream", "state": "suspended"}},
+                    "status": {
+                      "jobStatus": {"state": "FINISHED"},
+                      "lifecycleState": "SUSPENDED",
+                      "jobManagerDeploymentStatus": "MISSING",
+                      "reconciliationStatus": {"state": "DEPLOYED"}
+                    }
+                  }]
+                }),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinksessionjobs",
+                StatusCode::OK,
+                json!({"items":[]}),
+            ),
+            MethodJsonResponse::new(
+                Method::PATCH,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments/orders-stream",
+                StatusCode::OK,
+                json!({}),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments",
+                StatusCode::OK,
+                json!({
+                  "items": [{
+                    "kind": "FlinkDeployment",
+                    "metadata": {"name": "orders-stream", "namespace": "analytics"},
+                    "spec": {"job": {"name": "orders-stream", "state": "running"}},
+                    "status": {
+                      "jobStatus": {"state": "RUNNING"},
+                      "lifecycleState": "READY",
+                      "reconciliationStatus": {"state": "READY"}
+                    }
+                  }]
+                }),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinksessionjobs",
+                StatusCode::OK,
+                json!({"items":[]}),
+            ),
+        ])
+        .await;
+        let app = start_app(live_config(&kubernetes.base_url, None)).await;
+        let client = Client::new();
+
+        let response = authorized(
+            &app,
+            client.post(format!(
+                "{}/api/jobs/demo/analytics/FlinkDeployment/orders-stream/actions/resume",
+                app.base_url
+            )),
+        )
+        .send()
+        .await
+        .expect("resume response should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload: Value = response
+            .json()
+            .await
+            .expect("resume payload should be JSON");
+        assert_eq!(payload["action"], "resume");
+        assert_eq!(payload["deleted"], false);
+        assert_eq!(payload["job"]["status"], "running");
+
+        app.shutdown();
+        kubernetes.shutdown();
+    }
+
+    #[tokio::test]
     async fn live_mode_action_route_returns_not_found_for_unknown_cluster() {
         let kubernetes = start_stateful_json_server(vec![
             MethodJsonResponse::new(
@@ -1207,29 +1388,65 @@ mod tests {
             .await
             .expect("page response should succeed");
         assert_eq!(page_response.status(), StatusCode::OK);
+        assert_eq!(
+            page_response.headers().get(header::CACHE_CONTROL),
+            Some(&header::HeaderValue::from_static(
+                super::SHELL_HTML_CACHE_CONTROL
+            ))
+        );
         let page_html = page_response.text().await.expect("page HTML should load");
         assert!(page_html.contains("Jobs + Status Dashboard"));
+        let asset_version = extract_version(&page_html, "/app.js?v=");
+        assert!(page_html.contains(&format!("/styles.css?v={asset_version}")));
 
         let app_js_response = client
-            .get(format!("{}/app.js", app.base_url))
+            .get(format!("{}/app.js?v={asset_version}", app.base_url))
             .send()
             .await
             .expect("app.js response should succeed");
         assert_eq!(app_js_response.status(), StatusCode::OK);
+        assert_eq!(
+            app_js_response.headers().get(header::CACHE_CONTROL),
+            Some(&header::HeaderValue::from_static(
+                super::VERSIONED_SHELL_ASSET_CACHE_CONTROL
+            ))
+        );
         let app_js = app_js_response.text().await.expect("app.js should load");
         assert!(app_js.contains("loadJobs"));
+        assert!(app_js.contains(&format!("./render.js?v={asset_version}")));
 
         let styles_response = client
-            .get(format!("{}/styles.css", app.base_url))
+            .get(format!("{}/styles.css?v={asset_version}", app.base_url))
             .send()
             .await
             .expect("styles.css response should succeed");
         assert_eq!(styles_response.status(), StatusCode::OK);
+        assert_eq!(
+            styles_response.headers().get(header::CACHE_CONTROL),
+            Some(&header::HeaderValue::from_static(
+                super::VERSIONED_SHELL_ASSET_CACHE_CONTROL
+            ))
+        );
         let styles = styles_response
             .text()
             .await
             .expect("styles.css should load");
         assert!(styles.contains(".page-header"));
+
+        let render_response = client
+            .get(format!("{}/render.js?v={asset_version}", app.base_url))
+            .send()
+            .await
+            .expect("render.js response should succeed");
+        assert_eq!(render_response.status(), StatusCode::OK);
+        assert_eq!(
+            render_response.headers().get(header::CACHE_CONTROL),
+            Some(&header::HeaderValue::from_static(
+                super::VERSIONED_SHELL_ASSET_CACHE_CONTROL
+            ))
+        );
+        let render_js = render_response.text().await.expect("render.js should load");
+        assert!(render_js.contains("renderTable"));
 
         app.shutdown();
         kubernetes.shutdown();
@@ -1802,6 +2019,18 @@ mod tests {
             .redirect(Policy::none())
             .build()
             .expect("client should build")
+    }
+
+    fn extract_version(body: &str, marker: &str) -> String {
+        let start = body
+            .find(marker)
+            .map(|index| index + marker.len())
+            .expect("marker should exist");
+        let suffix = &body[start..];
+        let end = suffix
+            .find('"')
+            .expect("versioned asset URL should end with quote");
+        suffix[..end].to_owned()
     }
 
     fn unused_local_url() -> String {

--- a/apps/api-rs/src/http/router.rs
+++ b/apps/api-rs/src/http/router.rs
@@ -1086,6 +1086,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn live_mode_action_route_rejects_missing_csrf_token() {
+        let kubernetes = start_stateful_json_server(vec![
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments",
+                StatusCode::OK,
+                json!({
+                  "items": [{
+                    "kind": "FlinkDeployment",
+                    "metadata": {"name": "orders-stream", "namespace": "analytics"},
+                    "spec": {"job": {"name": "orders-stream", "state": "running"}},
+                    "status": {"jobStatus": {"state": "RUNNING"}}
+                  }]
+                }),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinksessionjobs",
+                StatusCode::OK,
+                json!({"items":[]}),
+            ),
+        ])
+        .await;
+        let app = start_app(live_config(&kubernetes.base_url, None)).await;
+        let client = Client::new();
+
+        let response = authorized_without_csrf(
+            &app,
+            client.post(format!(
+                "{}/api/jobs/demo/analytics/FlinkDeployment/orders-stream/actions/suspend",
+                app.base_url
+            )),
+        )
+        .send()
+        .await
+        .expect("action response should succeed");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let payload: Value = response.json().await.expect("payload should be JSON");
+        assert_eq!(payload["error"], "Invalid CSRF token");
+
+        app.shutdown();
+        kubernetes.shutdown();
+    }
+
+    #[tokio::test]
+    async fn live_mode_action_route_rejects_invalid_csrf_token() {
+        let kubernetes = start_stateful_json_server(vec![
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinkdeployments",
+                StatusCode::OK,
+                json!({
+                  "items": [{
+                    "kind": "FlinkDeployment",
+                    "metadata": {"name": "orders-stream", "namespace": "analytics"},
+                    "spec": {"job": {"name": "orders-stream", "state": "running"}},
+                    "status": {"jobStatus": {"state": "RUNNING"}}
+                  }]
+                }),
+            ),
+            MethodJsonResponse::new(
+                Method::GET,
+                "/apis/flink.apache.org/v1beta1/namespaces/analytics/flinksessionjobs",
+                StatusCode::OK,
+                json!({"items":[]}),
+            ),
+        ])
+        .await;
+        let app = start_app(live_config(&kubernetes.base_url, None)).await;
+        let client = Client::new();
+
+        let response = authorized_without_csrf(
+            &app,
+            client
+                .post(format!(
+                    "{}/api/jobs/demo/analytics/FlinkDeployment/orders-stream/actions/suspend",
+                    app.base_url
+                ))
+                .header("x-csrf-token", "wrong-token"),
+        )
+        .send()
+        .await
+        .expect("action response should succeed");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let payload: Value = response.json().await.expect("payload should be JSON");
+        assert_eq!(payload["error"], "Invalid CSRF token");
+
+        app.shutdown();
+        kubernetes.shutdown();
+    }
+
+    #[tokio::test]
     async fn live_mode_serves_shell_assets_without_auth_headers() {
         let flink = start_mock_json_server(vec![(
             "/jobs/overview".to_owned(),
@@ -1405,6 +1497,7 @@ mod tests {
     struct RunningServer {
         base_url: String,
         session_cookie: Option<String>,
+        session_csrf_token: Option<String>,
         task: JoinHandle<()>,
     }
 
@@ -1443,6 +1536,7 @@ mod tests {
         RunningServer {
             base_url: format!("http://{}", address),
             session_cookie: session.as_ref().map(|(cookie, _)| cookie.clone()),
+            session_csrf_token: session.as_ref().map(|(_, csrf_token)| csrf_token.clone()),
             task,
         }
     }
@@ -1482,6 +1576,7 @@ mod tests {
         RunningServer {
             base_url: format!("http://{}", address),
             session_cookie: None,
+            session_csrf_token: None,
             task,
         }
     }
@@ -1536,6 +1631,7 @@ mod tests {
         RunningServer {
             base_url: format!("http://{}", address),
             session_cookie: None,
+            session_csrf_token: None,
             task,
         }
     }
@@ -1584,6 +1680,7 @@ mod tests {
         RunningServer {
             base_url: format!("http://{}", address),
             session_cookie: None,
+            session_csrf_token: None,
             task,
         }
     }
@@ -1680,6 +1777,19 @@ mod tests {
     }
 
     fn authorized(app: &RunningServer, request: RequestBuilder) -> RequestBuilder {
+        if let Some(cookie) = &app.session_cookie {
+            let request = request.header(reqwest::header::COOKIE, cookie);
+            if let Some(csrf_token) = &app.session_csrf_token {
+                request.header("x-csrf-token", csrf_token)
+            } else {
+                request
+            }
+        } else {
+            request
+        }
+    }
+
+    fn authorized_without_csrf(app: &RunningServer, request: RequestBuilder) -> RequestBuilder {
         if let Some(cookie) = &app.session_cookie {
             request.header(reqwest::header::COOKIE, cookie)
         } else {

--- a/apps/api-rs/src/service/jobs_service.rs
+++ b/apps/api-rs/src/service/jobs_service.rs
@@ -65,12 +65,28 @@ impl JobsService {
         kind: &str,
         name: &str,
     ) -> Result<Option<Job>> {
-        Ok(self.list_jobs(false).await?.into_iter().find(|job| {
-            job.cluster == cluster
-                && job.namespace == namespace
-                && job.kind == kind
-                && job.resource_name == name
-        }))
+        self.get_job_by_locator_with_refresh(cluster, namespace, kind, name, false)
+            .await
+    }
+
+    pub async fn get_job_by_locator_with_refresh(
+        &self,
+        cluster: &str,
+        namespace: &str,
+        kind: &str,
+        name: &str,
+        force_refresh: bool,
+    ) -> Result<Option<Job>> {
+        Ok(self
+            .list_jobs(force_refresh)
+            .await?
+            .into_iter()
+            .find(|job| {
+                job.cluster == cluster
+                    && job.namespace == namespace
+                    && job.kind == kind
+                    && job.resource_name == name
+            }))
     }
 
     async fn load_jobs(&self) -> Result<Vec<Job>> {
@@ -170,6 +186,24 @@ mod tests {
         let service = JobsService::new(fixture_config());
         let job = service
             .get_job_by_locator("demo", "analytics", "FlinkDeployment", "orders-stream")
+            .await
+            .expect("job lookup should succeed")
+            .expect("job should exist");
+
+        assert_eq!(job.job_name, "orders-stream");
+    }
+
+    #[tokio::test]
+    async fn jobs_service_can_force_refresh_a_job_by_locator() {
+        let service = JobsService::new(fixture_config());
+        let job = service
+            .get_job_by_locator_with_refresh(
+                "demo",
+                "analytics",
+                "FlinkDeployment",
+                "orders-stream",
+                true,
+            )
             .await
             .expect("job lookup should succeed")
             .expect("job should exist");

--- a/apps/api-rs/src/state.rs
+++ b/apps/api-rs/src/state.rs
@@ -2,10 +2,14 @@ use crate::auth::AuthService;
 use crate::config::AppConfig;
 use crate::http::metrics::MetricsState;
 use crate::service::jobs_service::JobsService;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::time::UNIX_EPOCH;
 
 #[derive(Clone)]
 pub struct AppState {
     pub config: AppConfig,
+    pub shell_asset_version: String,
     pub jobs_service: JobsService,
     pub metrics: MetricsState,
     pub auth: AuthService,
@@ -17,7 +21,31 @@ impl AppState {
             jobs_service: JobsService::new(config.clone()),
             metrics: MetricsState::new(),
             auth: AuthService::new(config.oidc_request_timeout_ms),
+            shell_asset_version: shell_asset_version(&config),
             config,
         }
     }
+}
+
+fn shell_asset_version(config: &AppConfig) -> String {
+    let mut hasher = DefaultHasher::new();
+
+    for asset_name in ["app.js", "render.js", "styles.css"] {
+        let path = config.static_dir().join(asset_name);
+        asset_name.hash(&mut hasher);
+
+        match std::fs::metadata(path) {
+            Ok(metadata) => {
+                metadata.len().hash(&mut hasher);
+                if let Ok(modified) = metadata.modified() {
+                    if let Ok(duration) = modified.duration_since(UNIX_EPOCH) {
+                        duration.as_millis().hash(&mut hasher);
+                    }
+                }
+            }
+            Err(_) => "missing".hash(&mut hasher),
+        }
+    }
+
+    format!("{:x}", hasher.finish())
 }

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -116,7 +116,7 @@ async function loadJobs(options = {}) {
     return;
   }
 
-  elements.content.innerHTML = '<div class="loading-state">Loading Flink jobs…</div>';
+  replaceHtml(elements.content, '<div class="loading-state">Loading Flink jobs…</div>');
 
   try {
     const response = await fetch('/api/jobs');
@@ -163,12 +163,15 @@ async function loadJobs(options = {}) {
     }
 
     const noAccess = status === 401 || status === 403;
-    elements.content.innerHTML = `
+    replaceHtml(
+      elements.content,
+      `
       <div class="${noAccess ? 'empty-state' : 'error-state'}">
         <strong>${noAccess ? 'No access to Flink resources.' : 'Failed to load jobs.'}</strong>
         <p>${error.message}</p>
       </div>
-    `;
+    `
+    );
   }
 }
 
@@ -177,18 +180,18 @@ function render() {
   elements.refreshButton.disabled = state.session.status === 'loading';
 
   if (!canLoadJobs()) {
-    elements.filters.innerHTML = '';
-    elements.summary.innerHTML = '';
+    replaceHtml(elements.filters, '');
+    replaceHtml(elements.summary, '');
     replaceChildren(elements.drawer, renderSignedOutDrawerNode(state.session));
     replaceChildren(elements.content, renderSessionStateNode(state.session));
     return;
   }
 
   const filteredJobs = filterJobs(state.jobs, state.filters);
-  elements.filters.innerHTML = renderFilters(state.jobs, state.filters);
-  elements.summary.innerHTML = `${renderSummary(filteredJobs)}${renderWarnings(filteredJobs)}`;
-  elements.content.innerHTML = renderTable(filteredJobs);
-  elements.drawer.innerHTML = renderDrawer(state.selectedJob, state.action);
+  replaceHtml(elements.filters, renderFilters(state.jobs, state.filters));
+  replaceHtml(elements.summary, `${renderSummary(filteredJobs)}${renderWarnings(filteredJobs)}`);
+  replaceHtml(elements.content, renderTable(filteredJobs));
+  replaceHtml(elements.drawer, renderDrawer(state.selectedJob, state.action));
 
   for (const key of ['cluster', 'namespace', 'status', 'search']) {
     const field = document.querySelector(`#${key}`);
@@ -205,7 +208,7 @@ function render() {
   document.querySelectorAll('[data-job-id]').forEach((button) => {
     button.addEventListener('click', () => {
       state.selectedJob = state.jobs.find((job) => job.id === button.dataset.jobId) || null;
-      elements.drawer.innerHTML = renderDrawer(state.selectedJob, state.action);
+      replaceHtml(elements.drawer, renderDrawer(state.selectedJob, state.action));
     });
   });
 
@@ -310,6 +313,14 @@ async function readJson(response) {
 
 function replaceChildren(element, ...nodes) {
   element.replaceChildren(...nodes.filter(Boolean));
+}
+
+function replaceHtml(element, html) {
+  replaceChildren(element, htmlFragment(html));
+}
+
+function htmlFragment(html) {
+  return document.createRange().createContextualFragment(String(html || ''));
 }
 
 function renderSessionChromeNode(session) {

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -227,18 +227,6 @@ function canLoadJobs() {
   return state.session.authenticated || state.session.status === 'legacy';
 }
 
-function renderSignedOutDrawer(session) {
-  if (session.status === 'loading') {
-    return '<p class="muted">Waiting for session bootstrap before loading dashboard details.</p>';
-  }
-
-  if (session.status === 'error') {
-    return '<p class="muted">Retry authentication to continue to the protected dashboard.</p>';
-  }
-
-  return '<p class="muted">Sign in to inspect deployment details, warnings, and cluster-specific job status.</p>';
-}
-
 async function submitJobAction(job, action) {
   state.action = {
     status: 'pending',
@@ -349,7 +337,7 @@ function renderSessionChromeNode(session) {
       ? session.user?.email || 'Session active'
       : session.status === 'loading'
         ? 'Loading authentication status…'
-        : 'Sign in to view protected job data';
+        : 'Sign in to view protected job data and action controls';
 
   chip.append(badge, detail);
   wrapper.append(chip);
@@ -408,12 +396,12 @@ function renderSignedOutDrawerNode(session) {
   }
 
   if (session.status === 'error') {
-    paragraph.textContent = 'Retry authentication to continue to the protected dashboard.';
+    paragraph.textContent = 'Retry authentication to continue to the protected v2 dashboard.';
     return paragraph;
   }
 
   paragraph.textContent =
-    'Sign in to inspect deployment details, warnings, and cluster-specific job status.';
+    'Sign in to inspect deployment details, warnings, and single-resource v2 job actions.';
   return paragraph;
 }
 
@@ -439,7 +427,7 @@ function renderSessionStateNode(session) {
     eyebrow.textContent = 'Authentication';
     title.textContent = 'Checking session…';
     message.textContent =
-      'We’re verifying whether you already have an active session before loading Flink job data.';
+      'We’re verifying whether you already have an active session before loading Flink job data and v2 action controls.';
   } else if (session.status === 'error') {
     eyebrow.textContent = 'Authentication error';
     title.textContent = 'We could not verify your session';
@@ -452,10 +440,10 @@ function renderSessionStateNode(session) {
     actions.append(retryLink);
   } else {
     eyebrow.textContent = 'Authentication required';
-    title.textContent = session.title || 'Sign in to view Flink jobs';
+    title.textContent = session.title || 'Sign in to manage Flink jobs';
     message.textContent =
       session.message ||
-      'This dashboard only loads cluster and job details after the server confirms an authenticated session.';
+      'This dashboard only loads protected cluster status, job details, and action controls after the server confirms an authenticated session.';
 
     const signInLink = document.createElement('a');
     signInLink.className = 'primary-button';

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -250,7 +250,12 @@ async function submitJobAction(job, action) {
   render();
 
   try {
-    const response = await fetch(jobActionHref(job, action), { method: 'POST' });
+    const response = await fetch(jobActionHref(job, action), {
+      method: 'POST',
+      headers: state.session.csrfToken
+        ? { 'x-csrf-token': state.session.csrfToken }
+        : {}
+    });
     const payload = await readJson(response);
 
     if (!response.ok) {

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -25,7 +25,14 @@ const state = {
     search: ''
   },
   selectedJob: null,
-  session: { ...DEFAULT_SESSION }
+  session: { ...DEFAULT_SESSION },
+  action: {
+    status: 'idle',
+    jobId: null,
+    action: null,
+    message: '',
+    deleted: false
+  }
 };
 
 const elements = {
@@ -103,7 +110,7 @@ async function bootstrapSession() {
   }
 }
 
-async function loadJobs() {
+async function loadJobs(options = {}) {
   if (!canLoadJobs()) {
     render();
     return;
@@ -123,11 +130,18 @@ async function loadJobs() {
     }
 
     state.jobs = payload.jobs;
+    const deletedSelectedJobId = options.deletedSelectedJobId || null;
     if (!state.selectedJob && state.jobs[0]) {
       state.selectedJob = state.jobs[0];
     } else if (state.selectedJob) {
-      state.selectedJob =
-        state.jobs.find((job) => job.id === state.selectedJob.id) || state.jobs[0] || null;
+      const refreshedSelection = state.jobs.find((job) => job.id === state.selectedJob.id);
+      if (refreshedSelection) {
+        state.selectedJob = refreshedSelection;
+      } else if (deletedSelectedJobId && deletedSelectedJobId === state.selectedJob.id) {
+        state.selectedJob = null;
+      } else {
+        state.selectedJob = state.jobs[0] || null;
+      }
     }
 
     render();
@@ -174,7 +188,7 @@ function render() {
   elements.filters.innerHTML = renderFilters(state.jobs, state.filters);
   elements.summary.innerHTML = `${renderSummary(filteredJobs)}${renderWarnings(filteredJobs)}`;
   elements.content.innerHTML = renderTable(filteredJobs);
-  elements.drawer.innerHTML = renderDrawer(state.selectedJob);
+  elements.drawer.innerHTML = renderDrawer(state.selectedJob, state.action);
 
   for (const key of ['cluster', 'namespace', 'status', 'search']) {
     const field = document.querySelector(`#${key}`);
@@ -191,7 +205,17 @@ function render() {
   document.querySelectorAll('[data-job-id]').forEach((button) => {
     button.addEventListener('click', () => {
       state.selectedJob = state.jobs.find((job) => job.id === button.dataset.jobId) || null;
-      elements.drawer.innerHTML = renderDrawer(state.selectedJob);
+      elements.drawer.innerHTML = renderDrawer(state.selectedJob, state.action);
+    });
+  });
+
+  document.querySelectorAll('[data-job-action]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const job = state.jobs.find((candidate) => candidate.id === button.dataset.jobId);
+      if (!job) {
+        return;
+      }
+      submitJobAction(job, button.dataset.jobAction);
     });
   });
 }
@@ -210,6 +234,53 @@ function renderSignedOutDrawer(session) {
   }
 
   return '<p class="muted">Sign in to inspect deployment details, warnings, and cluster-specific job status.</p>';
+}
+
+async function submitJobAction(job, action) {
+  state.action = {
+    status: 'pending',
+    jobId: job.id,
+    action,
+    message: '',
+    deleted: false
+  };
+  render();
+
+  try {
+    const response = await fetch(jobActionHref(job, action), { method: 'POST' });
+    const payload = await readJson(response);
+
+    if (!response.ok) {
+      const error = new Error(payload.details || payload.error || 'Action failed.');
+      error.status = response.status;
+      throw error;
+    }
+
+    state.action = {
+      status: 'success',
+      jobId: job.id,
+      action,
+      message: payload.message || 'Action completed successfully.',
+      deleted: payload.deleted === true
+    };
+
+    await loadJobs({
+      deletedSelectedJobId: payload.deleted === true ? job.id : null
+    });
+  } catch (error) {
+    state.action = {
+      status: 'error',
+      jobId: job.id,
+      action,
+      message: error instanceof Error ? error.message : 'Action failed.',
+      deleted: false
+    };
+    render();
+  }
+}
+
+function jobActionHref(job, action) {
+  return `/api/jobs/${encodeURIComponent(job.cluster)}/${encodeURIComponent(job.namespace)}/${encodeURIComponent(job.kind)}/${encodeURIComponent(job.resourceName)}/actions/${encodeURIComponent(action)}`;
 }
 
 function normalizeSessionPayload(payload) {

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -12,8 +12,8 @@
         <p class="eyebrow">Flink on Kubernetes</p>
         <h1>Jobs + Status Dashboard</h1>
         <p class="subtitle">
-          Read-only v1 for viewing FlinkDeployment and FlinkSessionJob status across
-          watched namespaces.
+          v2 baseline for viewing FlinkDeployment and FlinkSessionJob status plus
+          single-resource suspend/resume/cancel actions across watched namespaces.
         </p>
       </div>
       <div class="header-actions">

--- a/apps/web/public/render.js
+++ b/apps/web/public/render.js
@@ -151,9 +151,14 @@ export function jobManagerProxyHref(job) {
   return `/api/jobs/${encodeURIComponent(job.id)}/jobmanager-proxy/`;
 }
 
-export function renderDrawer(job) {
+export function renderDrawer(job, actionState = defaultDrawerActionState()) {
   if (!job) {
     return `
+      ${
+        actionState.status === 'success' && actionState.deleted
+          ? `<div class="feedback-banner feedback-success">${escapeHtml(actionState.message || 'Resource deleted successfully.')}</div>`
+          : ''
+      }
       <p class="muted">Select a job to inspect deployment details and warnings.</p>
     `;
   }
@@ -171,6 +176,8 @@ export function renderDrawer(job) {
       <p><strong>Flink version:</strong> ${job.flinkVersion || 'unknown'}</p>
       <p><strong>Mode:</strong> ${job.deploymentMode || 'unknown'}</p>
       <p><strong>Last update:</strong> ${job.lastUpdatedAt || '—'}</p>
+      ${renderActionFeedback(actionState, job)}
+      ${renderJobActions(job, actionState)}
       ${
         proxyHref
           ? `<p><a href="${proxyHref}" target="_blank" rel="noreferrer">Open JobManager UI</a></p>`
@@ -186,6 +193,63 @@ export function renderDrawer(job) {
       <h3>Status details</h3>
       <pre>${escapeHtml(JSON.stringify(job.details, null, 2))}</pre>
     </div>
+  `;
+}
+
+function renderActionFeedback(actionState, job) {
+  if (!job || actionState.jobId !== job.id) {
+    return '';
+  }
+
+  if (actionState.status === 'success') {
+    return `<div class="feedback-banner feedback-success">${escapeHtml(actionState.message || 'Action completed successfully.')}</div>`;
+  }
+
+  if (actionState.status === 'error') {
+    return `<div class="feedback-banner feedback-error">${escapeHtml(actionState.message || 'Action failed.')}</div>`;
+  }
+
+  return '';
+}
+
+function renderJobActions(job, actionState) {
+  const actions = [
+    ['suspend', 'Suspend', job.actions?.suspend],
+    ['resume', 'Resume', job.actions?.resume],
+    ['cancel', 'Cancel', job.actions?.cancel]
+  ];
+
+  return `
+    <div class="job-actions">
+      <h3>Actions</h3>
+      <div class="job-action-list">
+        ${actions
+          .map(([action, label, state]) => renderJobActionButton(job, action, label, state, actionState))
+          .join('')}
+      </div>
+    </div>
+  `;
+}
+
+function renderJobActionButton(job, action, label, state = {}, actionState) {
+  const pending = actionState.status === 'pending' && actionState.jobId === job.id;
+  const enabled = state.enabled === true && !pending;
+  const reason =
+    pending && actionState.action === action
+      ? `Submitting ${label.toLowerCase()}…`
+      : state.reason || '';
+
+  return `
+    <button
+      class="secondary-button job-action-button job-action-${action}"
+      type="button"
+      data-job-id="${escapeHtml(job.id)}"
+      data-job-action="${action}"
+      ${enabled ? '' : 'disabled'}
+      ${reason ? `title="${escapeHtml(reason)}"` : ''}
+    >
+      ${pending && actionState.action === action ? `${label}…` : label}
+    </button>
   `;
 }
 
@@ -282,6 +346,16 @@ function renderSessionAction(session) {
 
 function hasUsableJobManagerUrl(value) {
   return /^https?:\/\//i.test(String(value || ''));
+}
+
+function defaultDrawerActionState() {
+  return {
+    status: 'idle',
+    jobId: null,
+    action: null,
+    message: '',
+    deleted: false
+  };
 }
 
 function escapeHtml(value) {

--- a/apps/web/public/render.js
+++ b/apps/web/public/render.js
@@ -266,7 +266,7 @@ export function renderSessionChrome(session) {
       ? session.user?.email || 'Session active'
       : session.status === 'loading'
         ? 'Loading authentication status…'
-        : 'Sign in to view protected job data';
+        : 'Sign in to view protected job data and action controls';
 
   return `
     <div class="session-chip">
@@ -284,16 +284,16 @@ export function renderAuthLoading() {
     <div class="auth-card">
       <p class="eyebrow">Authentication</p>
       <h2>Checking session…</h2>
-      <p class="muted">We’re verifying whether you already have an active session before loading Flink job data.</p>
+      <p class="muted">We’re verifying whether you already have an active session before loading Flink job data and v2 action controls.</p>
     </div>
   `;
 }
 
 export function renderSignedOutShell(session = {}) {
-  const title = session.title || 'Sign in to view Flink jobs';
+  const title = session.title || 'Sign in to manage Flink jobs';
   const message =
     session.message ||
-    'This dashboard only loads cluster and job details after the server confirms an authenticated session.';
+    'This dashboard only loads protected cluster status, job details, and action controls after the server confirms an authenticated session.';
   const loginUrl = session.loginUrl || '/auth/login';
 
   return `

--- a/apps/web/public/render.js
+++ b/apps/web/public/render.js
@@ -1,5 +1,5 @@
 export function statusClass(value) {
-  return `status-badge status-${String(value || 'unknown').toLowerCase()}`;
+  return `status-badge status-${sanitizeClassToken(value)}`;
 }
 
 export function summarizeJobs(jobs) {
@@ -59,7 +59,7 @@ export function renderFilters(jobs, filters) {
         ${values
           .map(
             (value) =>
-              `<option value="${value}" ${filters[key] === value ? 'selected' : ''}>${value}</option>`
+              `<option value="${escapeHtml(value)}" ${filters[key] === value ? 'selected' : ''}>${escapeHtml(value)}</option>`
           )
           .join('')}
       </select>
@@ -72,7 +72,7 @@ export function renderFilters(jobs, filters) {
     ${select('Status', 'status', statuses)}
     <div class="field">
       <label for="search">Search</label>
-      <input id="search" type="search" value="${filters.search || ''}" placeholder="resource or job name" />
+      <input id="search" type="search" value="${escapeHtml(filters.search || '')}" placeholder="resource or job name" />
     </div>
   `;
 }
@@ -125,15 +125,15 @@ export function renderTable(jobs) {
             (job) => `
               <tr>
                 <td>
-                  <button class="row-button" data-job-id="${job.id}">
-                    <strong>${job.jobName}</strong><br />
-                    <span class="muted">${job.resourceName}</span>
+                  <button class="row-button" data-job-id="${escapeHtml(job.id)}">
+                    <strong>${escapeHtml(job.jobName)}</strong><br />
+                    <span class="muted">${escapeHtml(job.resourceName)}</span>
                   </button>
                 </td>
-                <td>${job.cluster}<br /><span class="muted">${job.namespace}</span></td>
-                <td>${job.kind}</td>
-                <td><span class="${statusClass(job.status)}">${job.status}</span></td>
-                <td>${job.lastUpdatedAt ? new Date(job.lastUpdatedAt).toLocaleString() : '—'}</td>
+                <td>${escapeHtml(job.cluster)}<br /><span class="muted">${escapeHtml(job.namespace)}</span></td>
+                <td>${escapeHtml(job.kind)}</td>
+                <td><span class="${statusClass(job.status)}">${escapeHtml(job.status)}</span></td>
+                <td>${escapeHtml(job.lastUpdatedAt ? new Date(job.lastUpdatedAt).toLocaleString() : '—')}</td>
               </tr>
             `
           )
@@ -167,26 +167,26 @@ export function renderDrawer(job, actionState = defaultDrawerActionState()) {
 
   return `
     <div>
-      <p class="eyebrow">${job.kind}</p>
-      <h2>${job.jobName}</h2>
-      <p><span class="${statusClass(job.status)}">${job.status}</span></p>
-      <p><strong>Cluster:</strong> ${job.cluster}</p>
-      <p><strong>Namespace:</strong> ${job.namespace}</p>
-      <p><strong>Resource:</strong> ${job.resourceName}</p>
-      <p><strong>Flink version:</strong> ${job.flinkVersion || 'unknown'}</p>
-      <p><strong>Mode:</strong> ${job.deploymentMode || 'unknown'}</p>
-      <p><strong>Last update:</strong> ${job.lastUpdatedAt || '—'}</p>
+      <p class="eyebrow">${escapeHtml(job.kind)}</p>
+      <h2>${escapeHtml(job.jobName)}</h2>
+      <p><span class="${statusClass(job.status)}">${escapeHtml(job.status)}</span></p>
+      <p><strong>Cluster:</strong> ${escapeHtml(job.cluster)}</p>
+      <p><strong>Namespace:</strong> ${escapeHtml(job.namespace)}</p>
+      <p><strong>Resource:</strong> ${escapeHtml(job.resourceName)}</p>
+      <p><strong>Flink version:</strong> ${escapeHtml(job.flinkVersion || 'unknown')}</p>
+      <p><strong>Mode:</strong> ${escapeHtml(job.deploymentMode || 'unknown')}</p>
+      <p><strong>Last update:</strong> ${escapeHtml(job.lastUpdatedAt || '—')}</p>
       ${renderActionFeedback(actionState, job)}
       ${renderJobActions(job, actionState)}
       ${
         proxyHref
-          ? `<p><a href="${proxyHref}" target="_blank" rel="noreferrer">Open JobManager UI</a></p>`
+          ? `<p><a href="${escapeHtml(proxyHref)}" target="_blank" rel="noreferrer">Open JobManager UI</a></p>`
           : '<p class="muted">No usable JobManager UI URL available.</p>'
       }
       ${
         job.warnings?.length
           ? `<ul class="warning-list">${job.warnings
-              .map((warning) => `<li>${warning}</li>`)
+              .map((warning) => `<li>${escapeHtml(warning)}</li>`)
               .join('')}</ul>`
           : '<p class="muted">No warnings reported.</p>'
       }
@@ -365,4 +365,10 @@ function escapeHtml(value) {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
+}
+
+function sanitizeClassToken(value) {
+  return String(value || 'unknown')
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9_-]/g, '-');
 }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -266,6 +266,44 @@ tr:hover {
   color: #ffd695;
 }
 
+.job-actions {
+  margin: 18px 0;
+}
+
+.job-action-list {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.job-action-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.job-action-cancel {
+  border-color: rgba(214, 69, 69, 0.45);
+}
+
+.feedback-banner {
+  margin: 16px 0;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+.feedback-success {
+  color: var(--healthy);
+  background: rgba(31, 157, 106, 0.12);
+  border-color: rgba(31, 157, 106, 0.3);
+}
+
+.feedback-error {
+  color: var(--error);
+  background: rgba(214, 69, 69, 0.12);
+  border-color: rgba(214, 69, 69, 0.3);
+}
+
 pre {
   white-space: pre-wrap;
   word-break: break-word;

--- a/deploy/api/deployment.yaml
+++ b/deploy/api/deployment.yaml
@@ -65,6 +65,8 @@ spec:
             - name: TRUST_PROXY_HEADERS
               value: "true"
             - name: WATCH_NAMESPACES
+              # Apply deploy/rbac/api-reader.yaml in each watched namespace so the
+              # service account can list and mutate Flink resources there.
               value: "analytics,payments"
           # When running in-cluster with the default K8S_* / service-account discovery
           # path, the app can synthesize a FlinkDeployment JobManager URL as

--- a/deploy/rbac/api-reader.yaml
+++ b/deploy/rbac/api-reader.yaml
@@ -10,7 +10,7 @@ metadata:
 rules:
   - apiGroups: ["flink.apache.org"]
     resources: ["flinkdeployments", "flinksessionjobs"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "patch", "delete"]
   - apiGroups: [""]
     resources: ["services", "pods"]
     verbs: ["get", "list"]

--- a/docs/architecture/flink-job-ui-v1.md
+++ b/docs/architecture/flink-job-ui-v1.md
@@ -1,81 +1,21 @@
-# Flink Job UI Architecture
+# Flink Job UI v1 Architecture (Historical)
 
-> This document started as the v1 read-only architecture note. It now also captures the v2 baseline single-resource control actions (`cancel`, `suspend`, `resume`) added on top of that foundation.
+This note captures the original v1 shape of the project: a read-only dashboard for listing
+Flink jobs and surfacing normalized status/warning data.
 
-## Scope
+The current product baseline is **v2**, which adds authenticated single-resource
+`cancel`, `suspend`, and `resume` actions on top of that foundation.
 
-- dashboard for listing Flink jobs and status
-- support `FlinkDeployment` and `FlinkSessionJob`
-- rely on Kubernetes operator CRs first, optional Flink REST enrichment second
-- support single-resource `cancel`, `suspend`, and `resume` actions through operator CR semantics
+## Current canonical docs
 
-## Why this shape
+- `docs/architecture/flink-job-ui-v2.md` — current architecture for the v2 baseline
+- `docs/ops/local-dev.md` — local development and deployment notes
 
-The repo was greenfield, so the implementation optimizes for:
+## What v1 referred to
 
-- minimal dependencies
-- easy local development via fixture mode
-- a clean adapter boundary between Kubernetes discovery and UI rendering
+- read-only listing/filtering for `FlinkDeployment` and `FlinkSessionJob`
+- normalized status, warnings, and details drawer rendering
+- optional Flink REST enrichment
+- no authenticated resource mutation actions
 
-## Components
-
-### Backend
-
-- `apps/api-rs/src/http/router.rs` — HTTP router, metrics, and static asset serving
-- `apps/api-rs/src/http/handlers/jobs.rs` — read + action handlers for job resources
-- `apps/api-rs/src/service/jobs_service.rs` — cached job aggregation
-- `apps/api-rs/src/adapters/k8s.rs` — Kubernetes reads + action mutations
-- `apps/api-rs/src/adapters/flink.rs` — optional Flink REST enrichment
-
-### Frontend
-
-- `apps/web/public/index.html` — shell
-- `apps/web/public/app.js` — fetch, action submission, and post-action refresh wiring
-- `apps/web/public/render.js` — rendering helpers, filter logic, and action controls/feedback
-
-## Data flow
-
-1. UI calls `GET /api/jobs`
-2. backend loads fixture data or reads operator CRs from Kubernetes
-3. backend normalizes resource status into canonical UI states and may synthesize an in-cluster `FlinkDeployment` JobManager URL (`http://<name>-rest.<namespace>.svc:8081/`) when operator status omits one
-4. backend optionally enriches results from Flink REST
-5. UI renders summary cards, filters, table, and details drawer
-6. Action submissions call the protected locator-based action endpoint and force an immediate refetch so the drawer/table reflect the authoritative post-action state
-
-## Canonical status vocabulary
-
-- `running`
-- `reconciling`
-- `suspended`
-- `failed`
-- `unknown`
-
-Raw status is still preserved in the details view for troubleshooting.
-
-## Action semantics
-
-- `suspend` patches the operator-managed resource into a suspended state
-- `resume` is only available for suspended resources
-- `cancel` deletes/removes the operator-managed resource and is terminal
-- unsupported action/state combinations stay disabled in the UI and return `409`-style API responses if called directly
-
-## Configuration
-
-- `FIXTURE_MODE=true` uses `fixtures/jobs.json`
-- `FLINK_UI_CLUSTERS_JSON` supports explicit cluster config
-- `K8S_*` env vars support a single-cluster deployment
-- the in-cluster auto-derived cluster path also enables `FlinkDeployment` JobManager URL discovery via the `<name>-rest.<namespace>.svc:8081` service convention
-
-## Protection model
-
-- The supported production runtime is the Rust service in `apps/api-rs`; both `npm start` and the example Kubernetes deployment execute that binary.
-- End-user authentication is owned by the application process via OIDC login, callback, logout, and a same-origin session cookie.
-- The signed-out shell and auth endpoints stay public enough to start the login flow, while `/api/*` is gated on the app-owned session.
-- `/metrics` is an operational endpoint. Keep it off the public ingress and expose it only on an internal-only service or scrape path.
-- Local fixture-mode development is intentionally ungated so a single developer can run the UI without provisioning SSO.
-
-## Next extension points
-
-- namespace or cluster-level watches instead of polling
-- authorization and identity-aware business logic on top of the session layer
-- savepoints and richer operator workflows after the baseline action surface is stable
+Use the v2 architecture note for the current system design and runtime behavior.

--- a/docs/architecture/flink-job-ui-v1.md
+++ b/docs/architecture/flink-job-ui-v1.md
@@ -1,11 +1,13 @@
-# Flink Job UI v1 Architecture
+# Flink Job UI Architecture
+
+> This document started as the v1 read-only architecture note. It now also captures the v2 baseline single-resource control actions (`cancel`, `suspend`, `resume`) added on top of that foundation.
 
 ## Scope
 
-- read-only dashboard
-- list Flink jobs and status
+- dashboard for listing Flink jobs and status
 - support `FlinkDeployment` and `FlinkSessionJob`
 - rely on Kubernetes operator CRs first, optional Flink REST enrichment second
+- support single-resource `cancel`, `suspend`, and `resume` actions through operator CR semantics
 
 ## Why this shape
 
@@ -20,15 +22,16 @@ The repo was greenfield, so the implementation optimizes for:
 ### Backend
 
 - `apps/api-rs/src/http/router.rs` — HTTP router, metrics, and static asset serving
+- `apps/api-rs/src/http/handlers/jobs.rs` — read + action handlers for job resources
 - `apps/api-rs/src/service/jobs_service.rs` — cached job aggregation
-- `apps/api-rs/src/adapters/k8s.rs` — Kubernetes reads + normalization inputs
+- `apps/api-rs/src/adapters/k8s.rs` — Kubernetes reads + action mutations
 - `apps/api-rs/src/adapters/flink.rs` — optional Flink REST enrichment
 
 ### Frontend
 
 - `apps/web/public/index.html` — shell
-- `apps/web/public/app.js` — fetch + interaction wiring
-- `apps/web/public/render.js` — rendering helpers and filter logic
+- `apps/web/public/app.js` — fetch, action submission, and post-action refresh wiring
+- `apps/web/public/render.js` — rendering helpers, filter logic, and action controls/feedback
 
 ## Data flow
 
@@ -37,6 +40,7 @@ The repo was greenfield, so the implementation optimizes for:
 3. backend normalizes resource status into canonical UI states and may synthesize an in-cluster `FlinkDeployment` JobManager URL (`http://<name>-rest.<namespace>.svc:8081/`) when operator status omits one
 4. backend optionally enriches results from Flink REST
 5. UI renders summary cards, filters, table, and details drawer
+6. Action submissions call the protected locator-based action endpoint and force an immediate refetch so the drawer/table reflect the authoritative post-action state
 
 ## Canonical status vocabulary
 
@@ -47,6 +51,13 @@ The repo was greenfield, so the implementation optimizes for:
 - `unknown`
 
 Raw status is still preserved in the details view for troubleshooting.
+
+## Action semantics
+
+- `suspend` patches the operator-managed resource into a suspended state
+- `resume` is only available for suspended resources
+- `cancel` deletes/removes the operator-managed resource and is terminal
+- unsupported action/state combinations stay disabled in the UI and return `409`-style API responses if called directly
 
 ## Configuration
 
@@ -67,4 +78,4 @@ Raw status is still preserved in the details view for troubleshooting.
 
 - namespace or cluster-level watches instead of polling
 - authorization and identity-aware business logic on top of the session layer
-- control actions like suspend/cancel after read-only v1 is accepted
+- savepoints and richer operator workflows after the baseline action surface is stable

--- a/docs/architecture/flink-job-ui-v2.md
+++ b/docs/architecture/flink-job-ui-v2.md
@@ -1,0 +1,99 @@
+# Flink Job UI v2 Baseline Architecture
+
+This document describes the current v2 baseline for the Flink Job UI: the original
+status dashboard plus authenticated single-resource control actions
+(`cancel`, `suspend`, `resume`).
+
+## Scope
+
+- dashboard for listing Flink jobs and status
+- support `FlinkDeployment` and `FlinkSessionJob`
+- rely on Kubernetes operator CRs first, optional Flink REST enrichment second
+- support authenticated single-resource `cancel`, `suspend`, and `resume` actions
+- refresh the authoritative resource state immediately after every action
+
+## Why this shape
+
+The implementation optimizes for:
+
+- minimal dependencies
+- a single Rust service that owns both shell delivery and protected APIs
+- easy local development via fixture mode
+- a clear adapter boundary between Kubernetes discovery, action mutation, and UI rendering
+
+## Components
+
+### Backend
+
+- `apps/api-rs/src/http/router.rs` — HTTP router, metrics, auth gate, and static shell asset serving
+- `apps/api-rs/src/http/handlers/jobs.rs` — protected list + action handlers for job resources
+- `apps/api-rs/src/service/jobs_service.rs` — cached job aggregation and post-action refresh lookup
+- `apps/api-rs/src/adapters/k8s.rs` — Kubernetes reads + action mutations
+- `apps/api-rs/src/adapters/flink.rs` — optional Flink REST enrichment
+- `apps/api-rs/src/domain/normalize.rs` — normalization into canonical UI states/action affordances
+
+### Frontend
+
+- `apps/web/public/index.html` — signed-out shell and authenticated layout frame
+- `apps/web/public/app.js` — auth bootstrap, job fetch, action submission, and DOM wiring
+- `apps/web/public/render.js` — rendering helpers, filter logic, and action controls/feedback
+- `apps/web/public/styles.css` — styling
+
+## Data flow
+
+1. The browser requests `/` and loads the current versioned shell assets.
+2. The frontend calls `GET /api/session` to discover whether an authenticated session exists.
+3. Once authenticated, the UI calls `GET /api/jobs`.
+4. The backend loads fixture data or reads operator CRs from Kubernetes.
+5. The backend normalizes resource status into canonical UI states and may synthesize an in-cluster `FlinkDeployment` JobManager URL (`http://<name>-rest.<namespace>.svc:8081/`) when operator status omits one.
+6. The backend optionally enriches results from Flink REST.
+7. The UI renders summary cards, filters, the table, the details drawer, and action controls.
+8. Action submissions call the protected locator-based action endpoint and immediately refetch so the table and drawer reflect the authoritative post-action state.
+
+## Canonical status vocabulary
+
+- `running`
+- `reconciling`
+- `suspended`
+- `failed`
+- `unknown`
+
+Raw status is still preserved in the details view for troubleshooting.
+
+## Action semantics
+
+- `suspend` patches the operator-managed resource into a suspended state
+- `resume` is only available for suspended resources
+- `cancel` deletes/removes the operator-managed resource and is terminal
+- unsupported action/state combinations stay disabled in the UI and return `409`-style API responses if called directly
+- CSRF protection stays enforced for every mutating action request
+
+## Configuration
+
+- `FIXTURE_MODE=true` uses `fixtures/jobs.json`
+- `FLINK_UI_CLUSTERS_JSON` supports explicit cluster config
+- `K8S_*` env vars support a single-cluster deployment
+- the in-cluster auto-derived cluster path also enables `FlinkDeployment` JobManager URL discovery via the `<name>-rest.<namespace>.svc:8081` service convention
+- shell HTML is served as the authoritative source for current JS/CSS asset versions; browsers cache versioned assets immutably
+
+## Protection model
+
+- The supported production runtime is the Rust service in `apps/api-rs`; both `npm start` and the example Kubernetes deployment execute that binary.
+- End-user authentication is owned by the application process via OIDC login, callback, logout, and a same-origin session cookie.
+- The signed-out shell and auth endpoints stay public enough to start the login flow, while `/api/*` is gated on the app-owned session.
+- `/metrics` is an operational endpoint. Keep it off the public ingress and expose it only on an internal-only service or scrape path.
+- Local fixture-mode development is intentionally ungated so a single developer can run the UI without provisioning SSO.
+
+## Known baseline limits
+
+- bulk actions and savepoints remain out of scope
+- fixture mode still renders action affordances but does not execute live mutations
+- JobManager UI proxying remains read-only; websocket/upgrade flows are not supported
+- `FlinkSessionJob` collection remains best-effort
+- production authorization rules beyond session authentication are still a future layer
+
+## Historical note
+
+The original read-only architecture note now lives at `docs/architecture/flink-job-ui-v1.md`
+as a short historical reference. This v2 document is the canonical architecture note for the
+current branch/runtime.

--- a/docs/ops/local-dev.md
+++ b/docs/ops/local-dev.md
@@ -8,6 +8,8 @@ npm run dev
 
 Open `http://localhost:3000`.
 
+Fixture mode keeps action execution disabled on purpose: the UI still shows the baseline control surface, but `cancel`, `suspend`, and `resume` are non-clickable because there is no live Kubernetes operator target behind the local fixture dataset.
+
 ## Runtime and auth model
 
 - `npm start` delegates to `npm run start:rust`, which runs the supported Rust backend in `apps/api-rs`.
@@ -103,5 +105,6 @@ Kubernetes/Flink upstream calls.
 - The default `npm start` / `npm run dev` path now runs the Rust backend in `apps/api-rs`.
 - `FlinkSessionJob` collection is best-effort; clusters without that CR kind still work.
 - Flink REST enrichment is optional and never blocks job listing.
+- Local fixture mode is still the safest way to exercise the read path; action execution requires a live or mocked Kubernetes API.
 - There is no separate Node backend runtime path anymore.
 - Do not expose `/metrics` on the public ingress; keep it on an internal-only operations path.

--- a/fixtures/jobs.json
+++ b/fixtures/jobs.json
@@ -16,6 +16,14 @@
       "startedAt": "2026-04-01T22:00:00.000Z",
       "nativeUiUrl": "https://flink.example.com/orders-stream/",
       "warnings": [],
+      "actions": {
+        "cancel": { "enabled": true },
+        "suspend": { "enabled": true },
+        "resume": {
+          "enabled": false,
+          "reason": "Resume is only available for suspended resources"
+        }
+      },
       "details": {
         "statusSummary": {
           "jobState": "RUNNING",
@@ -48,6 +56,14 @@
       "warnings": [
         "Flink REST enrichment unavailable: no JobManager URL"
       ],
+      "actions": {
+        "cancel": { "enabled": true },
+        "suspend": { "enabled": true },
+        "resume": {
+          "enabled": false,
+          "reason": "Resume is only available for suspended resources"
+        }
+      },
       "details": {
         "statusSummary": {
           "reconciliationState": "UPGRADING"
@@ -70,6 +86,14 @@
       "startedAt": "2026-03-29T09:00:00.000Z",
       "nativeUiUrl": null,
       "warnings": [],
+      "actions": {
+        "cancel": { "enabled": true },
+        "suspend": {
+          "enabled": false,
+          "reason": "Already suspended"
+        },
+        "resume": { "enabled": true }
+      },
       "details": {
         "statusSummary": {
           "jobState": "SUSPENDED"
@@ -94,6 +118,17 @@
       "warnings": [
         "Restart backoff exceeded on JobManager"
       ],
+      "actions": {
+        "cancel": { "enabled": true },
+        "suspend": {
+          "enabled": false,
+          "reason": "Suspend is only available for active resources"
+        },
+        "resume": {
+          "enabled": false,
+          "reason": "Resume is only available for suspended resources"
+        }
+      },
       "details": {
         "statusSummary": {
           "error": "Restart backoff exceeded on JobManager"

--- a/tests/web/render.test.js
+++ b/tests/web/render.test.js
@@ -48,8 +48,41 @@ test('renderDrawer includes warnings and sanitized status details', () => {
   assert.match(html, /Open JobManager UI/);
   assert.match(html, /Status details/);
   assert.match(html, /&quot;statusSummary&quot;/);
+  assert.match(html, /data-job-action="cancel"/);
+  assert.match(html, /data-job-action="suspend"/);
+  assert.match(html, /data-job-action="resume"/);
   assert.doesNotMatch(html, /"metadata"/);
   assert.doesNotMatch(html, /"spec"/);
+});
+
+test('renderDrawer reflects enabled and disabled action controls', () => {
+  const runningHtml = renderDrawer(fixture.jobs[0]);
+  assert.doesNotMatch(runningHtml, /data-job-action="suspend"[^>]*disabled/);
+  assert.match(runningHtml, /data-job-action="resume"[^>]*disabled/);
+
+  const suspendedHtml = renderDrawer(fixture.jobs[2]);
+  assert.match(suspendedHtml, /data-job-action="suspend"[^>]*disabled/);
+  assert.doesNotMatch(suspendedHtml, /data-job-action="resume"[^>]*disabled/);
+});
+
+test('renderDrawer shows action feedback and deleted-state success banner', () => {
+  const successHtml = renderDrawer(fixture.jobs[0], {
+    status: 'success',
+    jobId: fixture.jobs[0].id,
+    action: 'suspend',
+    message: 'Resource suspended successfully.',
+    deleted: false
+  });
+  assert.match(successHtml, /Resource suspended successfully/);
+
+  const deletedHtml = renderDrawer(null, {
+    status: 'success',
+    jobId: fixture.jobs[0].id,
+    action: 'cancel',
+    message: 'Resource deleted successfully.',
+    deleted: true
+  });
+  assert.match(deletedHtml, /Resource deleted successfully/);
 });
 
 test('jobManagerProxyHref returns a same-domain proxy path for usable URLs only', () => {

--- a/tests/web/render.test.js
+++ b/tests/web/render.test.js
@@ -121,7 +121,11 @@ test('renderWarnings highlights partial enrichment state', () => {
   assert.match(html, /partial enrichment warnings/);
 });
 
-test('renderSignedOutShell renders sign-in call to action', () => {
+test('renderSignedOutShell renders v2 sign-in call to action', () => {
+  const defaultHtml = renderSignedOutShell();
+  assert.match(defaultHtml, /Sign in to manage Flink jobs/);
+  assert.match(defaultHtml, /protected cluster status, job details, and action controls/);
+
   const html = renderSignedOutShell({
     loginUrl: '/auth/login',
     title: 'Sign in required',
@@ -135,7 +139,9 @@ test('renderSignedOutShell renders sign-in call to action', () => {
 });
 
 test('renderAuthLoading and renderAuthError expose bootstrap states', () => {
-  assert.match(renderAuthLoading(), /Checking session/);
+  const loadingHtml = renderAuthLoading();
+  assert.match(loadingHtml, /Checking session/);
+  assert.match(loadingHtml, /v2 action controls/);
 
   const errorHtml = renderAuthError({
     error: 'OIDC discovery failed',

--- a/tests/web/render.test.js
+++ b/tests/web/render.test.js
@@ -85,6 +85,22 @@ test('renderDrawer shows action feedback and deleted-state success banner', () =
   assert.match(deletedHtml, /Resource deleted successfully/);
 });
 
+test('renderDrawer escapes untrusted job fields in the action UI path', () => {
+  const html = renderDrawer({
+    ...fixture.jobs[0],
+    kind: '<img src=x onerror=alert(1)>',
+    jobName: '<script>alert(1)</script>',
+    resourceName: '<b>orders</b>',
+    cluster: 'demo"><script>alert(2)</script>',
+    namespace: '<svg/onload=alert(3)>',
+    warnings: ['<img src=x onerror=alert(4)>']
+  });
+
+  assert.doesNotMatch(html, /<script>alert/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html, /&lt;img src=x onerror=alert\(4\)&gt;/);
+});
+
 test('jobManagerProxyHref returns a same-domain proxy path for usable URLs only', () => {
   assert.equal(
     jobManagerProxyHref(fixture.jobs[0]),


### PR DESCRIPTION
Closes #36

## Summary
- add protected single-resource cancel/suspend/resume actions for `FlinkDeployment` and `FlinkSessionJob`
- enforce operator-resource action eligibility in both the API and the drawer UI, including immediate post-action refresh/feedback
- document the new baseline and keep fixture mode read-only by disabling action execution there

## Details
- adds `POST /api/jobs/{cluster}/{namespace}/{kind}/{name}/actions/{action}` in the Rust runtime
- keeps one shared public action contract with explicit per-kind Kubernetes mutation handling
- treats post-cancel disappearance as a success-path UI state
- adds backend adapter/router tests and frontend render coverage for enabled/disabled controls and feedback banners

## Verification
- `cargo fmt --manifest-path apps/api-rs/Cargo.toml --check`
- `cargo test --manifest-path apps/api-rs/Cargo.toml`
- `node --test tests/web/render.test.js`
- `npm run build`
- `npm run ci:smoke`

## Notes
- Non-goals preserved: bulk actions and savepoints.

## Summary by Sourcery

Add backend and frontend support for single-job cancel, suspend, and resume actions with appropriate eligibility enforcement and feedback.

New Features:
- Introduce a protected POST job action endpoint to trigger cancel, suspend, and resume operations on individual Flink jobs via Kubernetes operator resources.
- Expose per-job action metadata (enabled/disabled plus reason) in the job domain model and API responses for use in the UI.
- Add drawer-level job action controls in the web UI, including submission wiring and post-action refresh logic, with support for handling deleted resources after cancel.

Enhancements:
- Enforce action eligibility server-side, returning conflict errors with human-readable reasons for disallowed or invalid actions.
- Implement Kubernetes adapter support for applying job actions by mapping them to appropriate PATCH/DELETE calls per resource kind.
- Ensure fixture mode remains read-only by deriving baseline actions but disabling their execution in both backend and UI.
- Extend metrics labeling and new test utilities to cover the action route, stateful mock Kubernetes interactions, and request recording for mutation verification.

Documentation:
- Update architecture, README, and local-dev docs to describe the new single-resource action flow, semantics, and fixture-mode behavior.

Tests:
- Add backend and frontend tests for the job action endpoint, Kubernetes mutations, action state derivation, fixture-mode restrictions, and UI rendering of action controls and feedback banners.